### PR TITLE
Update the repository metadata.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ keywords = [ "knurling", "mmio", "register", "derive"]
 license = "MIT OR Apache-2.0"
 name = "derive-mmio"
 readme = "README.md"
-repository = "https://github.com/ferrous-systems/derive-mmio"
+repository = "https://github.com/knurling-rs/derive-mmio"
 version = "0.1.0"
 
 [dependencies]

--- a/macro/Cargo.toml
+++ b/macro/Cargo.toml
@@ -1,7 +1,13 @@
 [package]
-name = "derive-mmio-macro"
-version = "0.1.0"
+authors = [ "Jonathan Pallant <jonathan.pallant@ferrous-systems.com>" ]
+categories = [ "embedded" ]
+description = "The proc-macro for derive-mmio"
 edition = "2021"
+license = "MIT OR Apache-2.0"
+name = "derive-mmio-macro"
+readme = "../README.md"
+repository = "https://github.com/knurling-rs/derive-mmio"
+version = "0.1.0"
 
 [lib]
 proc-macro = true


### PR DESCRIPTION
We've moved to knurling, so set the Cargo metadata to match.