### PR TITLE
Add pointer method

### DIFF
--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -11,8 +11,6 @@ struct Uart {
 }
 
 fn main() {
-    println!("Hello, world!");
-
     let mut uart = Uart {
         data: 0xA,
         control: 0xC,
@@ -21,11 +19,14 @@ fn main() {
 
     // Safety: We're pointing at a real object
     let mut mmio_uart = unsafe { Uart::new_mmio(core::ptr::addr_of_mut!(uart)) };
+    println!("sample UART is @ {:p}", core::ptr::addr_of_mut!(uart));
 
     println!("data = {}", mmio_uart.read_data());
+    println!("data register is at = {:p}", mmio_uart.pointer_to_data());
     mmio_uart.modify_control(|f| {
         println!("control was {f}, is now 32");
         32
     });
     println!("control = {}", mmio_uart.read_control());
+    println!("control register is @ {:p}", mmio_uart.pointer_to_control());
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,8 +54,9 @@ struct Uart {
 Note that your struct must be `repr(C)` and we will check this.
 
 The `derive_mmio::Mmio` derive-macro will generate some new methods and types
-for you. You can see this for yourself with `cargo expand`, but our example will
-expand to something like:
+for you. You can see this for yourself with `cargo doc` (or `cargo expand` if
+you have installed `cargo-expand`), but our example will expand to something
+like:
 
 ```rust
 // this is your type, unchanged


### PR DESCRIPTION
Adds methods called `pointer_to_xxx`.

Requires #12 to go it in first, as they touch the same docs.

Closes #14.