### PR TITLE
Check for padding and support RO fields.

### DIFF
--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -5,16 +5,27 @@
 #[derive(derive_mmio::Mmio)]
 #[repr(C)]
 struct Uart {
+    // this is read-only by default
     data: u32,
+    // you can be explicit if you like
+    #[mmio(RW)]
     control: u32,
+    // this field is read-only (no write_x or modify_x method)
+    #[mmio(RO)]
+    status: u32,
+    // this is ignored
     _reserved: u32,
+    // this will introduce padding, which will fail the compilation
+    // _reserved2: u8,
 }
 
 fn main() {
     let mut uart = Uart {
         data: 0xA,
         control: 0xC,
+        status: 0xF,
         _reserved: 0,
+        // _reserved2: 0,
     };
 
     // Safety: We're pointing at a real object
@@ -22,11 +33,17 @@ fn main() {
     println!("sample UART is @ {:p}", core::ptr::addr_of_mut!(uart));
 
     println!("data = {}", mmio_uart.read_data());
+    mmio_uart.write_data(0x0B);
+    println!("data = {}", mmio_uart.read_data());
     println!("data register is at = {:p}", mmio_uart.pointer_to_data());
+
     mmio_uart.modify_control(|f| {
         println!("control was {f}, is now 32");
         32
     });
     println!("control = {}", mmio_uart.read_control());
     println!("control register is @ {:p}", mmio_uart.pointer_to_control());
+
+    println!("status = {}", mmio_uart.read_status());
+    println!("status register is @ {:p}", mmio_uart.pointer_to_status());
 }


### PR DESCRIPTION
Now supports:

```rust
#[derive(derive_mmio::Mmio)]
#[repr(C)]
struct Uart {
    // this is read-only by default
    data: u32,
    // you can be explicit if you like
    #[mmio(RW)]
    control: u32,
    // this field is read-only (no write_x or modify_x method)
    #[mmio(RO)]
    status: u32,
    // this is ignored
    _reserved: u32,
    // this will introduce padding, which will fail the compilation
    // _reserved2: u8,
}
```

The padding is checked by verifying that the sum of the size of each field equals the size of the struct. The access is controlled using a attribute (and is RW by default).

Fixes #1 and #11.
