### PR TITLE
Release v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,8 +28,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-* The `fn new_mmio` and `fn new_mmio_at` functions are now cost
-* We no longer emit a different version of `fn new_mmio_at` using exposed
+- The `fn new_mmio` and `fn new_mmio_at` functions are now cost
+- We no longer emit a different version of `fn new_mmio_at` using exposed
   provenance on Rust version 1.84 or higher - because that API is not (yet)
   const.
 
@@ -37,18 +37,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-* `pointer_to_xxx` methods
-* Support for `mmio(RO)` and `mmio(RW)` attributes to mark fields as read-only or read-write
-* A check for padding within the struct (which is not allowed)
+- `pointer_to_xxx` methods
+- Support for `mmio(RO)` and `mmio(RW)` attributes to mark fields as read-only or read-write
+- A check for padding within the struct (which is not allowed)
 
 ### Changed
 
-* `read_xxx` methods now require `&mut self`
+- `read_xxx` methods now require `&mut self`
 
 ## [v0.1.0] - 2025-02-14
 
-* First release
-* Provides `read_xxx`, `write_xxx` and `modify_xxx` methods
+- First release
+- Provides `read_xxx`, `write_xxx` and `modify_xxx` methods
 
 [Unreleased]: https://github.com/knurling-rs/derive-mmio/compare/derive-mmio-v0.4.0...HEAD
 [v0.4.0]: https://github.com/knurling-rs/derive-mmio/compare/derive-mmio-v0.4.0...derive-mmio-v0.4.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v0.4.0] - 2025-04-04
+
 ### Changed
 
 - Compile time check for padding now works reliably
@@ -48,7 +50,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * First release
 * Provides `read_xxx`, `write_xxx` and `modify_xxx` methods
 
-[Unreleased]: https://github.com/knurling-rs/derive-mmio/compare/derive-mmio-v0.3.0...HEAD
+[Unreleased]: https://github.com/knurling-rs/derive-mmio/compare/derive-mmio-v0.4.0...HEAD
+[v0.4.0]: https://github.com/knurling-rs/derive-mmio/compare/derive-mmio-v0.4.0...derive-mmio-v0.4.0
 [v0.3.0]: https://github.com/knurling-rs/derive-mmio/compare/derive-mmio-v0.2.0...derive-mmio-v0.3.0
 [v0.2.0]: https://github.com/knurling-rs/derive-mmio/compare/derive-mmio-v0.1.0...derive-mmio-v0.2.0
 [v0.1.0]: https://github.com/knurling-rs/derive-mmio/releases/tag/derive-mmio-v0.1.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,11 +9,11 @@ name = "derive-mmio"
 readme = "README.md"
 repository = "https://github.com/knurling-rs/derive-mmio"
 rust-version = "1.70"
-version = "0.3.0"
+version = "0.4.0"
 
 [dependencies]
-derive-mmio-macro = { version = "=0.3.0", path = "./macro" }
-defmt = { version = "0.3", optional = true }
+derive-mmio-macro = { version = "=0.4.0", path = "./macro" }
+defmt = { version = "1", optional = true }
 rustversion = "1"
 
 [features]

--- a/macro/Cargo.toml
+++ b/macro/Cargo.toml
@@ -8,7 +8,7 @@ name = "derive-mmio-macro"
 readme = "../README.md"
 repository = "https://github.com/knurling-rs/derive-mmio"
 rust-version = "1.70"
-version = "0.3.0"
+version = "0.4.0"
 
 [lib]
 proc-macro = true


### PR DESCRIPTION
This is the update to release derive-mmio v0.4.0

Once merged it needs a `cargo publish` and a `git tag -a derive-mmio-v0.4.0 && git push --tags`.
