### PR TITLE
Replace '(inner)' with '(Inner)'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - `${field}_shared_unchecked` function to access inner arrays is now `unsafe`
+- Renamed `#[mmio(inner)]` to `#[mmio(Inner)]`
 
 ## [v0.5.0] - 2025-05-29
 

--- a/examples/inner_block.rs
+++ b/examples/inner_block.rs
@@ -28,12 +28,12 @@ mod inner {
 #[repr(C)]
 pub struct Uart {
     control: u32,
-    #[mmio(inner)]
+    #[mmio(Inner)]
     bank_0: inner::UartBank,
-    #[mmio(inner)]
+    #[mmio(Inner)]
     bank_1: inner::UartBank,
     // Arrays also work.
-    #[mmio(inner)]
+    #[mmio(Inner)]
     array: [inner::UartBank; 2],
 }
 

--- a/examples/no_std/src/main.rs
+++ b/examples/no_std/src/main.rs
@@ -19,7 +19,7 @@ struct Uart {
     // This is explicitly read-write
     #[mmio(Read, Write)]
     control: u32,
-    #[mmio(inner)]
+    #[mmio(Inner)]
     bank_0: inner::UartBank,
     // Array of registers
     array: [u32; 4],

--- a/macro/src/lib.rs
+++ b/macro/src/lib.rs
@@ -270,10 +270,10 @@ impl FieldParser {
                     abort!(attr.span(), "`Failed to parse #[mmio(...)]`");
                 };
                 let unexpected_meta_printout =
-                    "`#[mmio(...)]` only supports 'Read', 'ReadWrite', 'Write', 'Modify' and 'inner' options";
+                    "`#[mmio(...)]` only supports 'Inner', 'Read', 'PureRead', 'Write', and 'Modify' options";
                 for meta in nested {
                     if let Meta::Path(path) = meta {
-                        if path.is_ident("inner") {
+                        if path.is_ident("Inner") {
                             return self.generate_access_method_for_inner_mmio_field(
                                 ident,
                                 field,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -210,7 +210,7 @@ let p: *mut u32 = mmio_uart.pointer_to_data();
 
 ### Inner Fields
 
-If you have a field that is annotated with `#[mmio(inner)]`, the derive macro
+If you have a field that is annotated with `#[mmio(Inner)]`, the derive macro
 will generate getters for that field. Note that the type of such 'inner' fields
 must be annotated with `#[derive(Mmio)]`.
 
@@ -221,7 +221,7 @@ and will have a lifetime tied to the outer MMIO structure.
 // Given
 #[derive(Mmio)]
 struct Peripheral {
-    #[mmio(inner)]
+    #[mmio(Inner)]
     some_inner: InnerType
 }
 
@@ -241,7 +241,7 @@ number of owned inner MMIO objects:
 // Given
 #[derive(Mmio)]
 struct Peripheral {
-    #[mmio(inner)]
+    #[mmio(Inner)]
     some_inner: InnerType
 }
 
@@ -261,7 +261,7 @@ access to non-mutable methods on the inner field.
 // Given
 #[derive(Mmio)]
 struct Peripheral {
-    #[mmio(inner)]
+    #[mmio(Inner)]
     some_inner: InnerType
 }
 
@@ -351,7 +351,7 @@ The access permission attributes work for array fields as well.
   function for the field.
 - `#[mmio(Modify)]`: The field can be modified. This will generate a modify
   function for the field which performs a Read-Modify-Write operation.
-- `#[mmio(inner)]`: The field is a register block. It must be a type which is
+- `#[mmio(Inner)]`: The field is a register block. It must be a type which is
   `#[derive(Mmio)]`, which will be verified using trait bounds. The derive macro
   will generate getter functions to retrieve a handle for the inner block, with
   the lifetime of the inner handle tied to the outer handle.
@@ -368,7 +368,7 @@ The following field types are supported and tested:
 - Arrays of [`u32`]
 - Bitfields implemented with [`bitbybit::bitfield`]
 - Other `#[derive(Mmio)]` types, if the field is annotated with the
-  `#[mmio(inner)]` attribute. Arrays of inner MMIO types are also allowed.
+  `#[mmio(Inner)]` attribute. Arrays of inner MMIO types are also allowed.
 
 [`bitbybit::bitfield`]: https://crates.io/crates/bitbybit
 

--- a/tests/constness.rs
+++ b/tests/constness.rs
@@ -12,7 +12,7 @@ struct UartBank {
 struct Uart {
     // you can be explicit if you like
     control: u32,
-    #[mmio(inner)]
+    #[mmio(Inner)]
     bank_0: UartBank,
 }
 

--- a/tests/inner_mmio.rs
+++ b/tests/inner_mmio.rs
@@ -11,9 +11,9 @@ struct UartBank {
 struct Uart {
     // you can be explicit if you like
     control: u32,
-    #[mmio(inner)]
+    #[mmio(Inner)]
     bank_0: UartBank,
-    #[mmio(inner)]
+    #[mmio(Inner)]
     bank_1: UartBank,
 }
 

--- a/tests/inner_mmio_array.rs
+++ b/tests/inner_mmio_array.rs
@@ -28,7 +28,7 @@ mod inner {
 #[repr(C)]
 pub struct Uart {
     control: u32,
-    #[mmio(inner)]
+    #[mmio(Inner)]
     banks: [inner::UartBank; 2],
 }
 

--- a/tests/no_compile/bad_inner_attr.stderr
+++ b/tests/no_compile/bad_inner_attr.stderr
@@ -1,4 +1,4 @@
-error: `#[mmio(...)]` only supports 'Read', 'ReadWrite', 'Write', 'Modify' and 'inner' options
+error: `#[mmio(...)]` only supports 'Inner', 'Read', 'PureRead', 'Write', and 'Modify' options
  --> tests/no_compile/bad_inner_attr.rs:4:5
   |
 4 |     #[mmio(RW)]

--- a/tests/no_compile/cant_fake_inner_block.rs
+++ b/tests/no_compile/cant_fake_inner_block.rs
@@ -16,9 +16,9 @@ struct MmioUartBank<'a> {
 struct Uart {
     // you can be explicit if you like
     control: u32,
-    #[mmio(inner)]
+    #[mmio(Inner)]
     bank_0: UartBank,
-    #[mmio(inner)]
+    #[mmio(Inner)]
     bank_1: UartBank,
 }
 

--- a/tests/no_compile/inner_array_invalid_type.rs
+++ b/tests/no_compile/inner_array_invalid_type.rs
@@ -16,7 +16,7 @@ struct MmioUartBank<'a> {
 #[repr(C)]
 pub struct Uart {
     control: u32,
-    #[mmio(inner)]
+    #[mmio(Inner)]
     banks: [UartBank; 2],
 }
 

--- a/tests/no_compile/inner_array_safe_unchecked.rs
+++ b/tests/no_compile/inner_array_safe_unchecked.rs
@@ -17,7 +17,7 @@ mod inner {
 #[derive(derive_mmio::Mmio)]
 #[repr(C)]
 struct Uart {
-    #[mmio(inner)]
+    #[mmio(Inner)]
     array: [inner::UartBank; 2],
 }
 

--- a/tests/no_compile/inner_mmio_double_borrow.rs
+++ b/tests/no_compile/inner_mmio_double_borrow.rs
@@ -11,9 +11,9 @@ struct UartBank {
 struct Uart {
     // you can be explicit if you like
     control: u32,
-    #[mmio(inner)]
+    #[mmio(Inner)]
     bank_0: UartBank,
-    #[mmio(inner)]
+    #[mmio(Inner)]
     bank_1: UartBank,
 }
 

--- a/tests/no_compile/inner_only_shared.rs
+++ b/tests/no_compile/inner_only_shared.rs
@@ -8,7 +8,7 @@ struct UartBank {
 #[derive(derive_mmio::Mmio)]
 #[repr(C)]
 struct Uart {
-    #[mmio(inner)]
+    #[mmio(Inner)]
     bank_0: UartBank,
 }
 


### PR DESCRIPTION
Also fixes the error message that list all the kinds of attribute.

Closes #55