### PR TITLE
Marks `${field}_shared_unchecked` as unsafe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `${field}_shared_unchecked` function to access inner arrays is now `unsafe`
+
 ## [v0.5.0] - 2025-05-29
 
 ### Added

--- a/macro/src/lib.rs
+++ b/macro/src/lib.rs
@@ -505,7 +505,7 @@ impl FieldParser {
             #[doc = "based on a raw pointer which might lead to undefined behaviour on invalid offsets."]
             #[doc = "Users MUST ensure that the offset is valid."]
             #[inline]
-            pub #const_token fn #field_ident_shared_unchecked(&self, index: usize) -> derive_mmio::SharedInner<#inner_mmio_path<'_>> {
+            pub unsafe #const_token fn #field_ident_shared_unchecked(&self, index: usize) -> derive_mmio::SharedInner<#inner_mmio_path<'_>> {
                 derive_mmio::SharedInner::__new_internal(
                     unsafe {
                         self.#private_steal_unchecked_func_name(index)

--- a/tests/no_compile/array_safe_unchecked.rs
+++ b/tests/no_compile/array_safe_unchecked.rs
@@ -1,0 +1,16 @@
+#[derive(derive_mmio::Mmio)]
+#[repr(C)]
+struct Uart {
+    array: [u32; 2],
+}
+
+fn main() {
+    let mut uart = Uart { array: [0; 2] };
+
+    // Safety: We're pointing at a real object
+    let mmio_uart = unsafe { Uart::new_mmio(core::ptr::addr_of_mut!(uart)) };
+
+    // we cannot safely access the array field without bounds checks
+
+    let _inner_bank = mmio_uart.read_array_unchecked(5);
+}

--- a/tests/no_compile/array_safe_unchecked.stderr
+++ b/tests/no_compile/array_safe_unchecked.stderr
@@ -1,0 +1,7 @@
+error[E0133]: call to unsafe function `MmioUart::<'_>::read_array_unchecked` is unsafe and requires unsafe function or block
+  --> tests/no_compile/array_safe_unchecked.rs:15:23
+   |
+15 |     let _inner_bank = mmio_uart.read_array_unchecked(5);
+   |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ call to unsafe function
+   |
+   = note: consult the function's documentation for information on how to avoid undefined behavior

--- a/tests/no_compile/inner_array_safe_unchecked.rs
+++ b/tests/no_compile/inner_array_safe_unchecked.rs
@@ -1,0 +1,35 @@
+mod inner {
+    #[derive(derive_mmio::Mmio)]
+    #[repr(C)]
+    pub struct UartBank {
+        data: u32,
+    }
+
+    impl UartBank {
+        pub fn fake() -> UartBank {
+            UartBank {
+                data: 0x2,
+            }
+        }
+    }
+}
+
+#[derive(derive_mmio::Mmio)]
+#[repr(C)]
+struct Uart {
+    #[mmio(inner)]
+    array: [inner::UartBank; 2],
+}
+
+fn main() {
+    let mut uart = Uart { array: [inner::UartBank::fake(), inner::UartBank::fake()] };
+
+    // Safety: We're pointing at a real object
+    let mut mmio_uart = unsafe { Uart::new_mmio(core::ptr::addr_of_mut!(uart)) };
+
+    // we cannot safely access the array field without bounds checks
+
+    let _inner_bank = mmio_uart.array_shared_unchecked(5);
+
+    let _inner_bank = mmio_uart.array_unchecked(5);
+}

--- a/tests/no_compile/inner_array_safe_unchecked.stderr
+++ b/tests/no_compile/inner_array_safe_unchecked.stderr
@@ -1,0 +1,15 @@
+error[E0133]: call to unsafe function `MmioUart::<'_>::array_shared_unchecked` is unsafe and requires unsafe function or block
+  --> tests/no_compile/inner_array_safe_unchecked.rs:32:23
+   |
+32 |     let _inner_bank = mmio_uart.array_shared_unchecked(5);
+   |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ call to unsafe function
+   |
+   = note: consult the function's documentation for information on how to avoid undefined behavior
+
+error[E0133]: call to unsafe function `MmioUart::<'_>::array_unchecked` is unsafe and requires unsafe function or block
+  --> tests/no_compile/inner_array_safe_unchecked.rs:34:23
+   |
+34 |     let _inner_bank = mmio_uart.array_unchecked(5);
+   |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ call to unsafe function
+   |
+   = note: consult the function's documentation for information on how to avoid undefined behavior

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,28 +1,37 @@
 #[test]
 fn all_tests() {
     let t = trybuild::TestCases::new();
+
+    // tests that pass
+
+    t.pass("tests/array_fields.rs");
     t.pass("tests/basic.rs");
     t.pass("tests/inner_mmio.rs");
-    t.pass("tests/no_ctors.rs");
-    t.pass("tests/array_fields.rs");
     t.pass("tests/inner_mmio_array.rs");
+    t.pass("tests/no_ctors.rs");
+
+    // tests that pass but need an specific rustc version
+
     if rustversion::cfg!(since(1.82)) {
         t.pass("tests/constness.rs");
     }
-    t.compile_fail("tests/no_compile/no_modify.rs");
-    t.compile_fail("tests/no_compile/read_only.rs");
-    t.compile_fail("tests/no_compile/inner_only_shared.rs");
-    t.compile_fail("tests/no_compile/inner_array_invalid_type.rs");
-    t.compile_fail("tests/no_compile/double_read.rs");
-    t.compile_fail("tests/no_compile/duplicate_field_attr.rs");
-    t.compile_fail("tests/no_compile/modify_standalone.rs");
-    t.compile_fail("tests/no_compile/modify_without_write.rs");
-    t.compile_fail("tests/no_compile/modify_without_read.rs");
+
+    // tests that fail
+
     t.compile_fail("tests/no_compile/bad_inner_attr.rs");
-    t.compile_fail("tests/no_compile/unimpl_send.rs");
     t.compile_fail("tests/no_compile/bad_outer_attr.rs");
     t.compile_fail("tests/no_compile/cant_fake_inner_block.rs");
+    t.compile_fail("tests/no_compile/double_read.rs");
+    t.compile_fail("tests/no_compile/duplicate_field_attr.rs");
+    t.compile_fail("tests/no_compile/inner_array_invalid_type.rs");
     t.compile_fail("tests/no_compile/inner_mmio_double_borrow.rs");
+    t.compile_fail("tests/no_compile/inner_only_shared.rs");
+    t.compile_fail("tests/no_compile/modify_standalone.rs");
+    t.compile_fail("tests/no_compile/modify_without_read.rs");
+    t.compile_fail("tests/no_compile/modify_without_write.rs");
+    t.compile_fail("tests/no_compile/no_modify.rs");
     t.compile_fail("tests/no_compile/padding_forbidden.rs");
+    t.compile_fail("tests/no_compile/read_only.rs");
     t.compile_fail("tests/no_compile/repr_c_mandatory.rs");
+    t.compile_fail("tests/no_compile/unimpl_send.rs");
 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -18,12 +18,14 @@ fn all_tests() {
 
     // tests that fail
 
+    t.compile_fail("tests/no_compile/array_safe_unchecked.rs");
     t.compile_fail("tests/no_compile/bad_inner_attr.rs");
     t.compile_fail("tests/no_compile/bad_outer_attr.rs");
     t.compile_fail("tests/no_compile/cant_fake_inner_block.rs");
     t.compile_fail("tests/no_compile/double_read.rs");
     t.compile_fail("tests/no_compile/duplicate_field_attr.rs");
     t.compile_fail("tests/no_compile/inner_array_invalid_type.rs");
+    t.compile_fail("tests/no_compile/inner_array_safe_unchecked.rs");
     t.compile_fail("tests/no_compile/inner_mmio_double_borrow.rs");
     t.compile_fail("tests/no_compile/inner_only_shared.rs");
     t.compile_fail("tests/no_compile/modify_standalone.rs");


### PR DESCRIPTION
Accessing without bounds checks is unsafe - it was an error that this function was not marked as unsafe.

Closes #56 