### PR TITLE
Bump to 0.6.1 for release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v0.6.1] - 2025-09-03
+
 ### Fixed
 
 - Keyword order for arrays of inner fields when used with with `const_inner`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,10 +9,10 @@ name = "derive-mmio"
 readme = "README.md"
 repository = "https://github.com/knurling-rs/derive-mmio"
 rust-version = "1.70"
-version = "0.6.0"
+version = "0.6.1"
 
 [dependencies]
-derive-mmio-macro = { version = "=0.6.0", path = "./macro" }
+derive-mmio-macro = { version = "=0.6.1", path = "./macro" }
 defmt = { version = "1", optional = true }
 rustversion = "1"
 

--- a/macro/Cargo.toml
+++ b/macro/Cargo.toml
@@ -8,7 +8,7 @@ name = "derive-mmio-macro"
 readme = "../README.md"
 repository = "https://github.com/knurling-rs/derive-mmio"
 rust-version = "1.70"
-version = "0.6.0"
+version = "0.6.1"
 
 [lib]
 proc-macro = true


### PR DESCRIPTION
Bumps version number of main crate and macros crate to 0.6.1, and updates CHANGELOG.md file.