### PR TITLE
Add API to iterate arrays of registers

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - id: set-matrix
         run: |
-          echo 'rust_versions={"rust": ["stable", "1.70"]}' >> "$GITHUB_OUTPUT"
+          echo 'rust_versions={"rust": ["stable", "1.85"]}' >> "$GITHUB_OUTPUT"
 
   # Build the library
   build:
@@ -86,7 +86,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - name: Install rust
+        run: |
+          rustup install 1.85
+          rustup default 1.85
       - run: cargo test
 
   # Build the docs for the library

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- API for getting the length of an array of registers (`len_XXX`)
+
+### Changed
+
+- Renamed the API for getting the length of an inner block of registers (from
+  `XXX_array_len` to `len_XXX`)
+- Bumped MSRV to 1.85
+
 ## [v0.6.1] - 2025-09-03
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 name = "derive-mmio"
 readme = "README.md"
 repository = "https://github.com/knurling-rs/derive-mmio"
-rust-version = "1.70"
+rust-version = "1.85"
 version = "0.6.1"
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ For more details about the framework check the documentation at
 
 ## MSRV
 
-The minimum supported Rust version is 1.76 (or Ferrocene 24.05). `derive-mmio`
+The minimum supported Rust version is 1.85 (or Ferrocene 25.05). `derive-mmio`
 is tested against the latest stable Rust version and the MSRV.
 
 ## Support

--- a/examples/array.rs
+++ b/examples/array.rs
@@ -44,4 +44,10 @@ fn main() {
     assert_eq!(ro_array_1, 0x3);
     println!("MMIO read-only array[0]: 0x{:X}", ro_array_0);
     println!("MMIO read-only array[1]: 0x{:X}", ro_array_1);
+
+    // Get the length of the arrays
+    assert_eq!(mmio_uart.len_array_0(), 4);
+    assert_eq!(mmio_uart.len_array_1(), 4);
+    assert_eq!(mmio_uart.len_array_read_only(), 4);
+    assert_eq!(mmio_uart.len_array_write_only(), 2);
 }

--- a/macro/src/lib.rs
+++ b/macro/src/lib.rs
@@ -839,6 +839,7 @@ impl FieldParser {
         let unchecked_write_fn_name = format_ident!("write_{}_unchecked", field_ident);
         let unchecked_modify_fn_name = format_ident!("modify_{}_unchecked", field_ident);
         let modify_fn_name = format_ident!("modify_{}", field_ident);
+        let array_len_func = format_ident!("len_{}", field_ident);
         let error_type = quote! { derive_mmio::OutOfBoundsError };
 
         access_methods.append_all(quote! {
@@ -855,6 +856,16 @@ impl FieldParser {
             #[inline(always)]
             pub #const_token fn #pointer_fn_name(&self) -> *mut #array_type{
                 unsafe { (*self.ptr).#field_ident.as_mut_ptr() }
+            }
+        });
+
+        access_methods.append_all(quote! {
+            #[doc = "Length of the array `"]
+            #[doc = stringify!(#field_ident)]
+            #[doc = "`."]
+            #[inline]
+            pub const fn #array_len_func(&self) -> usize {
+                #array_len
             }
         });
 

--- a/macro/src/lib.rs
+++ b/macro/src/lib.rs
@@ -412,7 +412,7 @@ impl FieldParser {
         self.bound_checks.push(quote! {
             derive_mmio::is_mmio::<#inner_mmio_path>();
         });
-        let array_len_func = format_ident!("{}_array_len", field_ident);
+        let array_len_func = format_ident!("len_{}", field_ident);
         let field_ident_unchecked = format_ident!("{}_unchecked", field_ident);
 
         let field_ident_shared = format_ident!("{}_shared", field_ident);
@@ -601,7 +601,7 @@ impl FieldParser {
                 )
             }
 
-            #[doc = "Length of the inner MMIO array`"]
+            #[doc = "Length of the inner MMIO array `"]
             #[doc = stringify!(#field_ident)]
             #[doc = "`."]
             #[inline]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -320,6 +320,10 @@ impl MmioUart {
     pub unsafe fn modify_bank_unchecked<F: FnOnce(u32) -> u32>(&mut self, index: usize, f: F) {
         // ...
     }
+
+    pub const fn len_bank(&self) -> usize {
+        4
+    }
 }
 ```
 

--- a/tests/inner_mmio_array.rs
+++ b/tests/inner_mmio_array.rs
@@ -40,7 +40,7 @@ fn main() {
 
     // Safety: We're pointing at a real object
     let mut mmio_uart = unsafe { Uart::new_mmio(core::ptr::addr_of_mut!(uart)) };
-    assert_eq!(mmio_uart.banks_array_len(), 2);
+    assert_eq!(mmio_uart.len_banks(), 2);
     let bank0 = mmio_uart.banks_shared(0).unwrap();
     assert_eq!(bank0.read_data(), 0x2);
     assert_eq!(bank0.read_status(), 0x3);

--- a/tests/no_compile/read_only.stderr
+++ b/tests/no_compile/read_only.stderr
@@ -9,6 +9,5 @@ error[E0599]: no method named `write_status` found for struct `MmioUart` in the 
    |
 help: there is a method `read_status` with a similar name
    |
-16 -     mmio_uart.write_status();
-16 +     mmio_uart.read_status();
-   |
+16 |     mmio_uart.read_status();
+   |               ~~~~~~~~~~~


### PR DESCRIPTION
1. Updates error outputs to match rustc 1.94.0 (4a4ef493e 2026-03-02)
2. Bump MSRV to 1.85 to avoid issues with dependencies
3. Renames `<foo>_array_len` to `len_<foo>` for inner MMIO arrays (breaking change)
4. Adds `len_<foo>` for arrays of registers
