### PR TITLE
 Make the generated struct as `#[repr(transparent)]`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `#[mmio(repr_c_wrapper)]` attribute that adds `#[repr(C)]` to the generated wrapper.
+
 ## [v0.6.1] - 2025-09-03
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Added
-
-- `#[mmio(repr_c_wrapper)]` attribute that adds `#[repr(C)]` to the generated wrapper.
-
 ## [v0.6.1] - 2025-09-03
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- The generated wrapper struct now `#[repr(transparent)]`.
+
 ## [v0.6.1] - 2025-09-03
 
 ### Fixed

--- a/macro/src/lib.rs
+++ b/macro/src/lib.rs
@@ -14,6 +14,7 @@ pub fn derive_mmio(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     // validate our input
     let input = parse_macro_input!(input as DeriveInput);
     let mut is_repr_c = false;
+    let mut repr_c_wrapper = false;
     let mut omit_ctor = false;
     let mut const_ptr = false;
     let mut const_inner = false;
@@ -33,8 +34,12 @@ pub fn derive_mmio(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
                         const_inner = true;
                         return Ok(());
                     }
+                    if meta.path.is_ident("repr_c_wrapper") {
+                        repr_c_wrapper = true;
+                        return Ok(());
+                    }
                     Err(meta.error(
-                        "invalid content of mmio attribute, allowed values: `no_ctors`, `const_ptr`, `const_inner`"
+                        "invalid content of mmio attribute, allowed values: `no_ctors`, `const_ptr`, `const_inner`, `repr_c_wrapper`"
                     ))
                 }) {
                     abort!(e);
@@ -58,6 +63,11 @@ pub fn derive_mmio(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     if !is_repr_c {
         abort_call_site!("`#[derive(Mmio)]` only works on repr(C) types");
     }
+    let repr = if repr_c_wrapper {
+        quote!(#[repr(C)])
+    } else {
+        quote!()
+    };
     let ident = input.ident;
     let wrapper_ident = format_ident!("Mmio{}", ident);
     let Data::Struct(ref s) = input.data else {
@@ -144,6 +154,7 @@ pub fn derive_mmio(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
         #[doc = "An MMIO wrapper for ["]
         #[doc = stringify!(#ident)]
         #[doc = "]"]
+        #repr
         pub struct #wrapper_ident<'a> {
             ptr: *mut #ident,
             phantom: core::marker::PhantomData<&'a ()>,

--- a/macro/src/lib.rs
+++ b/macro/src/lib.rs
@@ -14,7 +14,6 @@ pub fn derive_mmio(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     // validate our input
     let input = parse_macro_input!(input as DeriveInput);
     let mut is_repr_c = false;
-    let mut repr_c_wrapper = false;
     let mut omit_ctor = false;
     let mut const_ptr = false;
     let mut const_inner = false;
@@ -34,12 +33,8 @@ pub fn derive_mmio(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
                         const_inner = true;
                         return Ok(());
                     }
-                    if meta.path.is_ident("repr_c_wrapper") {
-                        repr_c_wrapper = true;
-                        return Ok(());
-                    }
                     Err(meta.error(
-                        "invalid content of mmio attribute, allowed values: `no_ctors`, `const_ptr`, `const_inner`, `repr_c_wrapper`"
+                        "invalid content of mmio attribute, allowed values: `no_ctors`, `const_ptr`, `const_inner`"
                     ))
                 }) {
                     abort!(e);
@@ -63,11 +58,6 @@ pub fn derive_mmio(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     if !is_repr_c {
         abort_call_site!("`#[derive(Mmio)]` only works on repr(C) types");
     }
-    let repr = if repr_c_wrapper {
-        quote!(#[repr(C)])
-    } else {
-        quote!()
-    };
     let ident = input.ident;
     let wrapper_ident = format_ident!("Mmio{}", ident);
     let Data::Struct(ref s) = input.data else {
@@ -154,7 +144,6 @@ pub fn derive_mmio(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
         #[doc = "An MMIO wrapper for ["]
         #[doc = stringify!(#ident)]
         #[doc = "]"]
-        #repr
         pub struct #wrapper_ident<'a> {
             ptr: *mut #ident,
             phantom: core::marker::PhantomData<&'a ()>,

--- a/macro/src/lib.rs
+++ b/macro/src/lib.rs
@@ -144,6 +144,7 @@ pub fn derive_mmio(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
         #[doc = "An MMIO wrapper for ["]
         #[doc = stringify!(#ident)]
         #[doc = "]"]
+        #[repr(transparent)]
         pub struct #wrapper_ident<'a> {
             ptr: *mut #ident,
             phantom: core::marker::PhantomData<&'a ()>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -337,8 +337,6 @@ with `#[derive(Mmio)]`:
   Requires Rust 1.83.0 or higher.
 - `#[mmio(const_inner)]`: Const getter methods for inner MMIO blocks. Requires Rust 1.83.0 or
   higher.
-- `#[mmio(repr_c_wrapper)]`: Add `#[repr(C)]` to the generated wrapper. Useful for generating
-C bindings.
 
 ### Field attributes
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -337,6 +337,8 @@ with `#[derive(Mmio)]`:
   Requires Rust 1.83.0 or higher.
 - `#[mmio(const_inner)]`: Const getter methods for inner MMIO blocks. Requires Rust 1.83.0 or
   higher.
+- `#[mmio(repr_c_wrapper)]`: Add `#[repr(C)]` to the generated wrapper. Useful for generating
+C bindings.
 
 ### Field attributes
 


### PR DESCRIPTION
Closes #67.