### PR TITLE
Bump to Rust 2024 edition, and use 1.85 as the MSRV

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
       matrix: ${{ fromJSON(needs.setup.outputs.matrix) }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Install rust
         run: |
           rustup install ${{ matrix.rust }}
@@ -45,7 +45,7 @@ jobs:
           - thumbv7em-none-eabihf
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Install rust
         run: |
           rustup install ${{ matrix.rust }}
@@ -63,7 +63,7 @@ jobs:
       matrix: ${{ fromJSON(needs.setup.outputs.matrix) }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Install rust
         run: |
           rustup install ${{ matrix.rust }}
@@ -86,7 +86,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Install rust
         run: |
           rustup install 1.95
@@ -104,7 +104,7 @@ jobs:
       matrix: ${{ fromJSON(needs.setup.outputs.matrix) }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Install rust
         run: |
           rustup install ${{ matrix.rust }}
@@ -118,7 +118,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Install rust
         run: |
           rustup install 1.95
@@ -140,7 +140,7 @@ jobs:
       matrix: ${{ fromJSON(needs.setup.outputs.matrix) }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Install rust
         run: |
           rustup install ${{ matrix.rust }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - id: set-matrix
         run: |
-          echo 'rust_versions={"rust": ["stable", "1.70"]}' >> "$GITHUB_OUTPUT"
+          echo 'rust_versions={"rust": ["stable", "1.85"]}' >> "$GITHUB_OUTPUT"
 
   # Build the library
   build:
@@ -80,14 +80,21 @@ jobs:
     steps:
       - run: /bin/true
 
-  # Test the library
+  # Test the library - but only on one fixed version because we have
+  # expected errors, and they change between releases
   test:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-      - run: cargo test
+      - name: Install rust
+        run: |
+          rustup install 1.95
+          rustup default 1.95
+      - name: Run Tests
+        run: |
+          rustc --version
+          cargo test
 
   # Build the docs for the library
   docs:
@@ -114,8 +121,9 @@ jobs:
         uses: actions/checkout@v4
       - name: Install rust
         run: |
-          rustup install stable
-          rustup default stable
+          rustup install 1.95
+          rustup default 1.95
+          rustup component add rustfmt
       - name: Format Check
         run: |
           cargo fmt --check

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,13 +2,13 @@
 authors = [ "Jonathan Pallant <jonathan.pallant@ferrous-systems.com>" ]
 categories = [ "embedded" ]
 description = "A mechanism for making it easier to access MMIO peripherals"
-edition = "2021"
+edition = "2024"
 keywords = [ "knurling", "mmio", "register", "derive"]
 license = "MIT OR Apache-2.0"
 name = "derive-mmio"
 readme = "README.md"
 repository = "https://github.com/knurling-rs/derive-mmio"
-rust-version = "1.70"
+rust-version = "1.85"
 version = "0.6.1"
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ For more details about the framework check the documentation at
 
 ## MSRV
 
-The minimum supported Rust version is 1.76 (or Ferrocene 24.05). `derive-mmio`
+The minimum supported Rust version is 1.85 (or Ferrocene 25.08). `derive-mmio`
 is tested against the latest stable Rust version and the MSRV.
 
 ## Support

--- a/examples/no_std/Cargo.toml
+++ b/examples/no_std/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "no_std"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 derive-mmio = { path = "../.." }

--- a/macro/Cargo.toml
+++ b/macro/Cargo.toml
@@ -2,12 +2,12 @@
 authors = [ "Jonathan Pallant <jonathan.pallant@ferrous-systems.com>" ]
 categories = [ "embedded" ]
 description = "The proc-macro for derive-mmio"
-edition = "2021"
+edition = "2024"
 license = "MIT OR Apache-2.0"
 name = "derive-mmio-macro"
 readme = "../README.md"
 repository = "https://github.com/knurling-rs/derive-mmio"
-rust-version = "1.70"
+rust-version = "1.85"
 version = "0.6.1"
 
 [lib]

--- a/macro/src/lib.rs
+++ b/macro/src/lib.rs
@@ -1,11 +1,11 @@
 //! The derive macro for the Mmio crate.
 
-use proc_macro2::TokenStream;
 use proc_macro_error2::{abort, abort_call_site, proc_macro_error};
-use quote::{format_ident, quote, ToTokens, TokenStreamExt};
+use proc_macro2::TokenStream;
+use quote::{ToTokens, TokenStreamExt, format_ident, quote};
 use syn::{
-    parse_macro_input, punctuated::Punctuated, spanned::Spanned, Data, DeriveInput, Field, Fields,
-    Ident, Meta, Path, Token, TypeArray, TypePath,
+    Data, DeriveInput, Field, Fields, Ident, Meta, Path, Token, TypeArray, TypePath,
+    parse_macro_input, punctuated::Punctuated, spanned::Spanned,
 };
 
 #[proc_macro_error]
@@ -63,7 +63,7 @@ pub fn derive_mmio(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let Data::Struct(ref s) = input.data else {
         abort_call_site!("`#[derive(Mmio)]` only supports struct");
     };
-    let Fields::Named(ref fields) = &s.fields else {
+    let Fields::Named(fields) = &s.fields else {
         abort_call_site!("`#[derive(Mmio)]` only supports structs with named fields");
     };
 
@@ -269,8 +269,7 @@ impl FieldParser {
                 else {
                     abort!(attr.span(), "`Failed to parse #[mmio(...)]`");
                 };
-                let unexpected_meta_printout =
-                    "`#[mmio(...)]` only supports 'Inner', 'Read', 'PureRead', 'Write', and 'Modify' options";
+                let unexpected_meta_printout = "`#[mmio(...)]` only supports 'Inner', 'Read', 'PureRead', 'Write', and 'Modify' options";
                 for meta in nested {
                     if let Meta::Path(path) = meta {
                         if path.is_ident("Inner") {

--- a/tests/no_compile/array_safe_unchecked.stderr
+++ b/tests/no_compile/array_safe_unchecked.stderr
@@ -1,4 +1,4 @@
-error[E0133]: call to unsafe function `MmioUart::<'_>::read_array_unchecked` is unsafe and requires unsafe function or block
+error[E0133]: call to unsafe function `MmioUart::<'_>::read_array_unchecked` is unsafe and requires unsafe block
   --> tests/no_compile/array_safe_unchecked.rs:15:23
    |
 15 |     let _inner_bank = mmio_uart.read_array_unchecked(5);

--- a/tests/no_compile/cant_fake_inner_block.stderr
+++ b/tests/no_compile/cant_fake_inner_block.stderr
@@ -1,7 +1,7 @@
 error[E0599]: no function or associated item named `new_mmio` found for struct `UartBank` in the current scope
   --> tests/no_compile/cant_fake_inner_block.rs:14:10
    |
-4  | struct UartBank {
+ 4 | struct UartBank {
    | --------------- function or associated item `new_mmio` not found for this struct
 ...
 14 | #[derive(derive_mmio::Mmio)]
@@ -9,28 +9,48 @@ error[E0599]: no function or associated item named `new_mmio` found for struct `
    |
    = note: this error originates in the derive macro `derive_mmio::Mmio` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: the trait bound `MmioUartBank<'_>: _MmioMarker` is not satisfied
+error[E0277]: the trait bound `MmioUartBank<'_>: derive_mmio::_MmioMarker` is not satisfied
   --> tests/no_compile/cant_fake_inner_block.rs:20:13
    |
 20 |     bank_0: UartBank,
-   |             ^^^^^^^^ the trait `_MmioMarker` is not implemented for `MmioUartBank<'_>`
+   |             ^^^^^^^^ unsatisfied trait bound
    |
-   = help: the trait `_MmioMarker` is implemented for `MmioUart<'_>`
+help: the trait `derive_mmio::_MmioMarker` is not implemented for `MmioUartBank<'_>`
+  --> tests/no_compile/cant_fake_inner_block.rs:9:1
+   |
+ 9 | struct MmioUartBank<'a> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^
+help: the trait `derive_mmio::_MmioMarker` is implemented for `MmioUart<'_>`
+  --> tests/no_compile/cant_fake_inner_block.rs:14:10
+   |
+14 | #[derive(derive_mmio::Mmio)]
+   |          ^^^^^^^^^^^^^^^^^
 note: required by a bound in `is_mmio`
   --> src/lib.rs
    |
    | pub const fn is_mmio<M: _MmioMarker>() {}
    |                         ^^^^^^^^^^^ required by this bound in `is_mmio`
+   = note: this error originates in the derive macro `derive_mmio::Mmio` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: the trait bound `MmioUartBank<'_>: _MmioMarker` is not satisfied
+error[E0277]: the trait bound `MmioUartBank<'_>: derive_mmio::_MmioMarker` is not satisfied
   --> tests/no_compile/cant_fake_inner_block.rs:22:13
    |
 22 |     bank_1: UartBank,
-   |             ^^^^^^^^ the trait `_MmioMarker` is not implemented for `MmioUartBank<'_>`
+   |             ^^^^^^^^ unsatisfied trait bound
    |
-   = help: the trait `_MmioMarker` is implemented for `MmioUart<'_>`
+help: the trait `derive_mmio::_MmioMarker` is not implemented for `MmioUartBank<'_>`
+  --> tests/no_compile/cant_fake_inner_block.rs:9:1
+   |
+ 9 | struct MmioUartBank<'a> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^
+help: the trait `derive_mmio::_MmioMarker` is implemented for `MmioUart<'_>`
+  --> tests/no_compile/cant_fake_inner_block.rs:14:10
+   |
+14 | #[derive(derive_mmio::Mmio)]
+   |          ^^^^^^^^^^^^^^^^^
 note: required by a bound in `is_mmio`
   --> src/lib.rs
    |
    | pub const fn is_mmio<M: _MmioMarker>() {}
    |                         ^^^^^^^^^^^ required by this bound in `is_mmio`
+   = note: this error originates in the derive macro `derive_mmio::Mmio` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/no_compile/double_read.stderr
+++ b/tests/no_compile/double_read.stderr
@@ -7,7 +7,7 @@ error: `#[mmio(...)]` found second read argument
 error[E0599]: no function or associated item named `new_mmio` found for struct `Uart` in the current scope
   --> tests/no_compile/double_read.rs:13:40
    |
-3  | struct Uart {
+ 3 | struct Uart {
    | ----------- function or associated item `new_mmio` not found for this struct
 ...
 13 |     let mut mmio_uart = unsafe { Uart::new_mmio(core::ptr::addr_of_mut!(uart)) };

--- a/tests/no_compile/duplicate_field_attr.stderr
+++ b/tests/no_compile/duplicate_field_attr.stderr
@@ -7,7 +7,7 @@ error: `#[mmio(...)]` found second write argument
 error[E0599]: no function or associated item named `new_mmio` found for struct `Uart` in the current scope
   --> tests/no_compile/duplicate_field_attr.rs:14:40
    |
-4  | struct Uart {
+ 4 | struct Uart {
    | ----------- function or associated item `new_mmio` not found for this struct
 ...
 14 |     let mut mmio_uart = unsafe { Uart::new_mmio(core::ptr::addr_of_mut!(uart)) };

--- a/tests/no_compile/inner_array_invalid_type.stderr
+++ b/tests/no_compile/inner_array_invalid_type.stderr
@@ -1,7 +1,7 @@
 error[E0599]: no function or associated item named `new_mmio` found for struct `UartBank` in the current scope
   --> tests/no_compile/inner_array_invalid_type.rs:15:10
    |
-4  | struct UartBank {
+ 4 | struct UartBank {
    | --------------- function or associated item `new_mmio` not found for this struct
 ...
 15 | #[derive(derive_mmio::Mmio)]
@@ -9,15 +9,25 @@ error[E0599]: no function or associated item named `new_mmio` found for struct `
    |
    = note: this error originates in the derive macro `derive_mmio::Mmio` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: the trait bound `MmioUartBank<'_>: _MmioMarker` is not satisfied
+error[E0277]: the trait bound `MmioUartBank<'_>: derive_mmio::_MmioMarker` is not satisfied
   --> tests/no_compile/inner_array_invalid_type.rs:20:13
    |
 20 |     banks: [UartBank; 2],
-   |             ^^^^^^^^ the trait `_MmioMarker` is not implemented for `MmioUartBank<'_>`
+   |             ^^^^^^^^ unsatisfied trait bound
    |
-   = help: the trait `_MmioMarker` is implemented for `MmioUart<'_>`
+help: the trait `derive_mmio::_MmioMarker` is not implemented for `MmioUartBank<'_>`
+  --> tests/no_compile/inner_array_invalid_type.rs:9:1
+   |
+ 9 | struct MmioUartBank<'a> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^
+help: the trait `derive_mmio::_MmioMarker` is implemented for `MmioUart<'_>`
+  --> tests/no_compile/inner_array_invalid_type.rs:15:10
+   |
+15 | #[derive(derive_mmio::Mmio)]
+   |          ^^^^^^^^^^^^^^^^^
 note: required by a bound in `is_mmio`
   --> src/lib.rs
    |
    | pub const fn is_mmio<M: _MmioMarker>() {}
    |                         ^^^^^^^^^^^ required by this bound in `is_mmio`
+   = note: this error originates in the derive macro `derive_mmio::Mmio` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/no_compile/inner_array_safe_unchecked.stderr
+++ b/tests/no_compile/inner_array_safe_unchecked.stderr
@@ -1,4 +1,4 @@
-error[E0133]: call to unsafe function `MmioUart::<'_>::array_shared_unchecked` is unsafe and requires unsafe function or block
+error[E0133]: call to unsafe function `MmioUart::<'_>::array_shared_unchecked` is unsafe and requires unsafe block
   --> tests/no_compile/inner_array_safe_unchecked.rs:32:23
    |
 32 |     let _inner_bank = mmio_uart.array_shared_unchecked(5);
@@ -6,7 +6,7 @@ error[E0133]: call to unsafe function `MmioUart::<'_>::array_shared_unchecked` i
    |
    = note: consult the function's documentation for information on how to avoid undefined behavior
 
-error[E0133]: call to unsafe function `MmioUart::<'_>::array_unchecked` is unsafe and requires unsafe function or block
+error[E0133]: call to unsafe function `MmioUart::<'_>::array_unchecked` is unsafe and requires unsafe block
   --> tests/no_compile/inner_array_safe_unchecked.rs:34:23
    |
 34 |     let _inner_bank = mmio_uart.array_unchecked(5);

--- a/tests/no_compile/modify_standalone.stderr
+++ b/tests/no_compile/modify_standalone.stderr
@@ -7,7 +7,7 @@ error: Detected Modify field attribute without read and/or write access specifie
 error[E0599]: no function or associated item named `new_mmio` found for struct `Uart` in the current scope
   --> tests/no_compile/modify_standalone.rs:15:40
    |
-4  | struct Uart {
+ 4 | struct Uart {
    | ----------- function or associated item `new_mmio` not found for this struct
 ...
 15 |     let mut mmio_uart = unsafe { Uart::new_mmio(core::ptr::addr_of_mut!(uart)) };

--- a/tests/no_compile/modify_without_read.stderr
+++ b/tests/no_compile/modify_without_read.stderr
@@ -7,7 +7,7 @@ error: Detected Modify field attribute without read and/or write access specifie
 error[E0599]: no function or associated item named `new_mmio` found for struct `Uart` in the current scope
   --> tests/no_compile/modify_without_read.rs:14:40
    |
-4  | struct Uart {
+ 4 | struct Uart {
    | ----------- function or associated item `new_mmio` not found for this struct
 ...
 14 |     let mut mmio_uart = unsafe { Uart::new_mmio(core::ptr::addr_of_mut!(uart)) };

--- a/tests/no_compile/modify_without_write.stderr
+++ b/tests/no_compile/modify_without_write.stderr
@@ -7,7 +7,7 @@ error: Detected Modify field attribute without read and/or write access specifie
 error[E0599]: no function or associated item named `new_mmio` found for struct `Uart` in the current scope
   --> tests/no_compile/modify_without_write.rs:14:40
    |
-4  | struct Uart {
+ 4 | struct Uart {
    | ----------- function or associated item `new_mmio` not found for this struct
 ...
 14 |     let mut mmio_uart = unsafe { Uart::new_mmio(core::ptr::addr_of_mut!(uart)) };

--- a/tests/no_compile/no_modify.stderr
+++ b/tests/no_compile/no_modify.stderr
@@ -1,7 +1,7 @@
-error[E0599]: no method named `modify_uart` found for struct `MmioUart` in the current scope
+error[E0599]: no method named `modify_uart` found for struct `MmioUart<'a>` in the current scope
   --> tests/no_compile/no_modify.rs:14:15
    |
-1  | #[derive(derive_mmio::Mmio)]
+ 1 | #[derive(derive_mmio::Mmio)]
    |          ----------------- method `modify_uart` not found for this struct
 ...
 14 |     mmio_uart.modify_uart();

--- a/tests/no_compile/read_only.stderr
+++ b/tests/no_compile/read_only.stderr
@@ -1,7 +1,7 @@
-error[E0599]: no method named `write_status` found for struct `MmioUart` in the current scope
+error[E0599]: no method named `write_status` found for struct `MmioUart<'a>` in the current scope
   --> tests/no_compile/read_only.rs:16:15
    |
-1  | #[derive(derive_mmio::Mmio)]
+ 1 | #[derive(derive_mmio::Mmio)]
    |          ----------------- method `write_status` not found for this struct
 ...
 16 |     mmio_uart.write_status();

--- a/tests/no_compile/unimpl_send.stderr
+++ b/tests/no_compile/unimpl_send.stderr
@@ -27,7 +27,7 @@ error[E0277]: `*const ()` cannot be sent between threads safely
 note: required for `__Wrapper<'_, *const ()>` to implement `Send`
   --> tests/no_compile/unimpl_send.rs:8:1
    |
-8  | #[negative_impl::negative_impl]
+ 8 | #[negative_impl::negative_impl]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: 2 redundant requirements hidden
    = note: required for `MmioCpuPrivateRegBlock<'_>` to implement `Send`


### PR DESCRIPTION
Rust 1.85 is the first with Edition 2024 support. We have dependencies that need 2024 edition and this solves the build failure.

Also updates the expected errors to what the latest stable prints.