### PR TITLE
Test examples

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -90,7 +90,7 @@ jobs:
         run: |
           rustup install 1.85
           rustup default 1.85
-      - run: cargo test
+      - run: cargo test --all-targets
 
   # Build the docs for the library
   docs:

--- a/examples/array.rs
+++ b/examples/array.rs
@@ -51,3 +51,8 @@ fn main() {
     assert_eq!(mmio_uart.len_array_read_only(), 4);
     assert_eq!(mmio_uart.len_array_write_only(), 2);
 }
+
+#[test]
+fn test_main() {
+    main()
+}

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -61,3 +61,8 @@ fn main() {
     let mmio_uart = unsafe { Uart::new_mmio(core::ptr::addr_of_mut!(uart)) };
     println!("status = {}", mmio_uart.read_status());
 }
+
+#[test]
+fn test_main() {
+    main()
+}

--- a/examples/inner_block.rs
+++ b/examples/inner_block.rs
@@ -84,3 +84,8 @@ fn main() {
     assert_eq!(bank_array_1.read_data(), 0x2);
     assert_eq!(bank_array_1.read_status(), 0x3);
 }
+
+#[test]
+fn test_main() {
+    main()
+}


### PR DESCRIPTION
Examples were linted in CI before, but not executed.
Since our examples don't have side-effects or spawn GUIs, etc. we can safely run them too in CI to ensure all the `assert`s in them hold true.

Should avoid repeats of #72 

I chose to add a test case to each example which calls the main function, then tell cargo test to also run tests in example code. (`--all-targets` is very confusing naming. It refers to test targets, not compiler targets).
An alternative implementation would be to explicitly `cargo run --example <name>` each example in the CI job. There is no `cargo run --examples`.

No changelog entry since this should™ have no effect on the end user.