### PR TITLE
Removes proc-macro-error2 and uses panic for error handling in the macro

### DIFF
--- a/macro/Cargo.toml
+++ b/macro/Cargo.toml
@@ -14,7 +14,6 @@ version = "0.6.1"
 proc-macro = true
 
 [dependencies]
-proc-macro-error2 = "2.0.1"
-proc-macro2 = "1.0.93"
-quote = "1.0.38"
-syn = "2.0.98"
+proc-macro2 = "1"
+quote = "1"
+syn = "2"

--- a/macro/src/lib.rs
+++ b/macro/src/lib.rs
@@ -1,14 +1,12 @@
 //! The derive macro for the Mmio crate.
 
 use proc_macro2::TokenStream;
-use proc_macro_error2::{abort, abort_call_site, proc_macro_error};
 use quote::{format_ident, quote, ToTokens, TokenStreamExt};
 use syn::{
     parse_macro_input, punctuated::Punctuated, spanned::Spanned, Data, DeriveInput, Field, Fields,
     Ident, Meta, Path, Token, TypeArray, TypePath,
 };
 
-#[proc_macro_error]
 #[proc_macro_derive(Mmio, attributes(mmio))]
 pub fn derive_mmio(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     // validate our input
@@ -37,7 +35,7 @@ pub fn derive_mmio(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
                         "invalid content of mmio attribute, allowed values: `no_ctors`, `const_ptr`, `const_inner`"
                     ))
                 }) {
-                    abort!(e);
+                    panic!("derive-mmio macro error parsing nested metadata: {e}");
                 };
             }
         }
@@ -56,15 +54,15 @@ pub fn derive_mmio(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
         }
     }
     if !is_repr_c {
-        abort_call_site!("`#[derive(Mmio)]` only works on repr(C) types");
+        panic!("`#[derive(Mmio)]` only works on repr(C) types");
     }
     let ident = input.ident;
     let wrapper_ident = format_ident!("Mmio{}", ident);
     let Data::Struct(ref s) = input.data else {
-        abort_call_site!("`#[derive(Mmio)]` only supports struct");
+        panic!("`#[derive(Mmio)]` only supports struct");
     };
     let Fields::Named(ref fields) = &s.fields else {
-        abort_call_site!("`#[derive(Mmio)]` only supports structs with named fields");
+        panic!("`#[derive(Mmio)]` only supports structs with named fields");
     };
 
     let config = FieldConfig {
@@ -268,7 +266,7 @@ impl FieldParser {
                 let Ok(nested) =
                     attr.parse_args_with(Punctuated::<Meta, Token![,]>::parse_terminated)
                 else {
-                    abort!(attr.span(), "`Failed to parse #[mmio(...)]`");
+                    panic!("Failed to parse #[mmio(...)] at {:?}", attr.span());
                 };
                 let unexpected_meta_printout =
                     "`#[mmio(...)]` only supports 'Inner', 'Read', 'PureRead', 'Write', and 'Modify' options";
@@ -282,39 +280,36 @@ impl FieldParser {
                             );
                         } else if path.is_ident("Read") {
                             if access.read.is_some() {
-                                abort!(attr.span(), "`#[mmio(...)]` found second read argument");
+                                panic!("#[mmio(...)]` found second read argument");
                             }
                             access.read = Some(ReadAccess::Normal);
                         } else if path.is_ident("PureRead") {
                             if access.read.is_some() {
-                                abort!(attr.span(), "`#[mmio(...)]` found second read argument");
+                                panic!("#[mmio(...)]` found second read argument");
                             }
                             access.read = Some(ReadAccess::Pure);
                         } else if path.is_ident("Write") {
                             if access.write {
-                                abort!(attr.span(), "`#[mmio(...)]` found second write argument");
+                                panic!("#[mmio(...)]` found second write argument");
                             }
                             access.write = true;
                         } else if path.is_ident("Modify") {
                             if access.modify {
-                                abort!(attr.span(), "`#[mmio(...)]` found second write argument");
+                                panic!("#[mmio(...)]` found second write argument");
                             }
                             access.modify = true;
                         } else {
-                            abort!(attr.span(), unexpected_meta_printout);
+                            panic!("{unexpected_meta_printout}");
                         }
                     } else {
-                        abort!(attr.span(), unexpected_meta_printout);
+                        panic!("{unexpected_meta_printout}");
                     }
                 }
             }
         }
 
         if access.modify && (access.read.is_none() || !access.write) {
-            abort!(
-                field.span(),
-                "Detected Modify field attribute without read and/or write access specifiers"
-            );
+            panic!("Detected Modify field attribute without read and/or write access specifiers");
         }
         access.convert_unmodified();
 
@@ -364,16 +359,14 @@ impl FieldParser {
                         element_type,
                     )
                 } else {
-                    abort!(
-                        array_type.span(),
+                    panic!(
                         "inner field array {} does not have a valid array type",
                         field.to_token_stream()
                     );
                 }
             }
             _ => {
-                abort!(
-                    field.span(),
+                panic!(
                     "inner field {} does not have a valid path",
                     field.to_token_stream()
                 );

--- a/tests/no_compile/bad_inner_attr.stderr
+++ b/tests/no_compile/bad_inner_attr.stderr
@@ -1,5 +1,7 @@
-error: `#[mmio(...)]` only supports 'Inner', 'Read', 'PureRead', 'Write', and 'Modify' options
- --> tests/no_compile/bad_inner_attr.rs:4:5
+error: proc-macro derive panicked
+ --> tests/no_compile/bad_inner_attr.rs:1:10
   |
-4 |     #[mmio(RW)]
-  |     ^
+1 | #[derive(derive_mmio::Mmio)]
+  |          ^^^^^^^^^^^^^^^^^
+  |
+  = help: message: `#[mmio(...)]` only supports 'Inner', 'Read', 'PureRead', 'Write', and 'Modify' options

--- a/tests/no_compile/bad_outer_attr.stderr
+++ b/tests/no_compile/bad_outer_attr.stderr
@@ -1,5 +1,7 @@
-error: invalid content of mmio attribute, allowed values: `no_ctors`, `const_ptr`, `const_inner`
- --> tests/no_compile/bad_outer_attr.rs:2:8
+error: proc-macro derive panicked
+ --> tests/no_compile/bad_outer_attr.rs:1:10
   |
-2 | #[mmio(no_ctors_x)]
-  |        ^^^^^^^^^^
+1 | #[derive(derive_mmio::Mmio)]
+  |          ^^^^^^^^^^^^^^^^^
+  |
+  = help: message: derive-mmio macro error parsing nested metadata: invalid content of mmio attribute, allowed values: `no_ctors`, `const_ptr`, `const_inner`

--- a/tests/no_compile/double_read.stderr
+++ b/tests/no_compile/double_read.stderr
@@ -1,8 +1,10 @@
-error: `#[mmio(...)]` found second read argument
- --> tests/no_compile/double_read.rs:5:5
+error: proc-macro derive panicked
+ --> tests/no_compile/double_read.rs:1:10
   |
-5 |     #[mmio(Read, PureRead)]
-  |     ^
+1 | #[derive(derive_mmio::Mmio)]
+  |          ^^^^^^^^^^^^^^^^^
+  |
+  = help: message: #[mmio(...)]` found second read argument
 
 error[E0599]: no function or associated item named `new_mmio` found for struct `Uart` in the current scope
   --> tests/no_compile/double_read.rs:13:40

--- a/tests/no_compile/duplicate_field_attr.stderr
+++ b/tests/no_compile/duplicate_field_attr.stderr
@@ -1,8 +1,10 @@
-error: `#[mmio(...)]` found second write argument
- --> tests/no_compile/duplicate_field_attr.rs:6:5
+error: proc-macro derive panicked
+ --> tests/no_compile/duplicate_field_attr.rs:2:10
   |
-6 |     #[mmio(Write, Read, Write)]
-  |     ^
+2 | #[derive(derive_mmio::Mmio)]
+  |          ^^^^^^^^^^^^^^^^^
+  |
+  = help: message: #[mmio(...)]` found second write argument
 
 error[E0599]: no function or associated item named `new_mmio` found for struct `Uart` in the current scope
   --> tests/no_compile/duplicate_field_attr.rs:14:40

--- a/tests/no_compile/modify_standalone.stderr
+++ b/tests/no_compile/modify_standalone.stderr
@@ -1,8 +1,10 @@
-error: Detected Modify field attribute without read and/or write access specifiers
- --> tests/no_compile/modify_standalone.rs:7:5
+error: proc-macro derive panicked
+ --> tests/no_compile/modify_standalone.rs:2:10
   |
-7 |     #[mmio(Modify)]
-  |     ^
+2 | #[derive(derive_mmio::Mmio)]
+  |          ^^^^^^^^^^^^^^^^^
+  |
+  = help: message: Detected Modify field attribute without read and/or write access specifiers
 
 error[E0599]: no function or associated item named `new_mmio` found for struct `Uart` in the current scope
   --> tests/no_compile/modify_standalone.rs:15:40

--- a/tests/no_compile/modify_without_read.stderr
+++ b/tests/no_compile/modify_without_read.stderr
@@ -1,8 +1,10 @@
-error: Detected Modify field attribute without read and/or write access specifiers
- --> tests/no_compile/modify_without_read.rs:6:5
+error: proc-macro derive panicked
+ --> tests/no_compile/modify_without_read.rs:2:10
   |
-6 |     #[mmio(Modify, Write)]
-  |     ^
+2 | #[derive(derive_mmio::Mmio)]
+  |          ^^^^^^^^^^^^^^^^^
+  |
+  = help: message: Detected Modify field attribute without read and/or write access specifiers
 
 error[E0599]: no function or associated item named `new_mmio` found for struct `Uart` in the current scope
   --> tests/no_compile/modify_without_read.rs:14:40

--- a/tests/no_compile/modify_without_write.stderr
+++ b/tests/no_compile/modify_without_write.stderr
@@ -1,8 +1,10 @@
-error: Detected Modify field attribute without read and/or write access specifiers
- --> tests/no_compile/modify_without_write.rs:6:5
+error: proc-macro derive panicked
+ --> tests/no_compile/modify_without_write.rs:2:10
   |
-6 |     #[mmio(Modify, PureRead)]
-  |     ^
+2 | #[derive(derive_mmio::Mmio)]
+  |          ^^^^^^^^^^^^^^^^^
+  |
+  = help: message: Detected Modify field attribute without read and/or write access specifiers
 
 error[E0599]: no function or associated item named `new_mmio` found for struct `Uart` in the current scope
   --> tests/no_compile/modify_without_write.rs:14:40

--- a/tests/no_compile/repr_c_mandatory.stderr
+++ b/tests/no_compile/repr_c_mandatory.stderr
@@ -1,7 +1,7 @@
-error: `#[derive(Mmio)]` only works on repr(C) types
+error: proc-macro derive panicked
  --> tests/no_compile/repr_c_mandatory.rs:1:10
   |
 1 | #[derive(derive_mmio::Mmio)]
   |          ^^^^^^^^^^^^^^^^^
   |
-  = note: this error originates in the derive macro `derive_mmio::Mmio` (in Nightly builds, run with -Z macro-backtrace for more info)
+  = help: message: `#[derive(Mmio)]` only works on repr(C) types


### PR DESCRIPTION
But now the errors are not as useful, because the line highlighted is the derive attribute on the struct type, not one of the inner attributes that is actually wrong.