### PR TITLE
Add Owned handles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,13 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - MMIO wrapper structures now implement `core::fmt::Debug`. The implementation simply shows
   the base address.
+- Zero-sized Owned Handles, in the form `struct OwnedXXX` (use `no_owned` option to disable)
 
 ## [v0.7.0] - 2026-06-29
 
 ### Added
 
 - API for getting the length of an array of registers (`len_XXX`)
-- Zero-sized Owned Handles, in the form `struct OwnedXXX` (use `no_owned` option to disable)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - API for getting the length of an array of registers (`len_XXX`)
+- Zero-sized Owned Handles, in the form `struct OwnedXXX` (use `no_owned` option to disable)
 
 ### Changed
 

--- a/examples/no_std/src/main.rs
+++ b/examples/no_std/src/main.rs
@@ -25,6 +25,28 @@ struct Uart {
     array: [u32; 4],
 }
 
+/// This is our UART driver - it is of zero size
+pub struct Driver {
+    uart: OwnedUart<{ Self::UART_BASE }>,
+}
+
+impl Driver {
+    const UART_BASE: usize = 0xE000_0000;
+
+    pub const fn new() -> Driver {
+        Driver {
+            uart: unsafe { OwnedUart::new() },
+        }
+    }
+
+    pub fn read_control(&mut self) -> u32 {
+        // safely create a handle by borrowing our Owned handle
+        let mut mmio_uart = self.uart.borrow_mut();
+        // used it to access the peripheral
+        mmio_uart.read_control()
+    }
+}
+
 #[panic_handler]
 fn panic(_info: &core::panic::PanicInfo) -> ! {
     loop {}

--- a/macro/src/lib.rs
+++ b/macro/src/lib.rs
@@ -222,6 +222,14 @@ fn try_derive_mmio(input: DeriveInput) -> syn::Result<proc_macro2::TokenStream> 
                     )
                 }
             }
+
+            impl<const BASE_ADDR: usize> ::core::fmt::Debug for #owned_ident<BASE_ADDR> {
+                fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                    f.debug_tuple(stringify!(#owned_ident))
+                        .field(&BASE_ADDR)
+                        .finish()
+                }
+            }
         })
     };
 

--- a/macro/src/lib.rs
+++ b/macro/src/lib.rs
@@ -19,6 +19,7 @@ pub fn derive_mmio(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
 fn try_derive_mmio(input: DeriveInput) -> syn::Result<proc_macro2::TokenStream> {
     let mut is_repr_c = false;
     let mut omit_ctor = false;
+    let mut omit_owned = false;
     let mut const_ptr = false;
     let mut const_inner = false;
     'attr: for attr in input.attrs.iter() {
@@ -27,6 +28,10 @@ fn try_derive_mmio(input: DeriveInput) -> syn::Result<proc_macro2::TokenStream> 
                 if let Err(e) = list.parse_nested_meta(|meta| {
                     if meta.path.is_ident("no_ctors") {
                         omit_ctor = true;
+                        return Ok(());
+                    }
+                    if meta.path.is_ident("no_owned") {
+                        omit_owned = true;
                         return Ok(());
                     }
                     if meta.path.is_ident("const_ptr") {
@@ -38,7 +43,7 @@ fn try_derive_mmio(input: DeriveInput) -> syn::Result<proc_macro2::TokenStream> 
                         return Ok(());
                     }
                     Err(meta.error(
-                        "invalid content of mmio attribute, allowed values: `no_ctors`, `const_ptr`, `const_inner`"
+                        "invalid content of mmio attribute, allowed values: `no_ctors`, `no_owned`, `const_ptr`, `const_inner`"
                     ))
                 }) {
                     return Err(syn::Error::new(input.span(), e));
@@ -67,6 +72,7 @@ fn try_derive_mmio(input: DeriveInput) -> syn::Result<proc_macro2::TokenStream> 
     }
     let ident = &input.ident;
     let wrapper_ident = format_ident!("Mmio{}", ident);
+    let owned_ident = format_ident!("Owned{}", ident);
     let Data::Struct(ref s) = input.data else {
         return Err(syn::Error::new(
             input.span(),
@@ -151,6 +157,60 @@ fn try_derive_mmio(input: DeriveInput) -> syn::Result<proc_macro2::TokenStream> 
         })
     };
 
+    let owned_handles = if omit_owned {
+        None
+    } else {
+        Some(quote! {
+            #[doc = "A zero-sized Owned wrapper for ["]
+            #[doc = stringify!(#ident)]
+            #[doc = "] at an address known at compile-time (`BASE_ADDR`)"]
+            pub struct #owned_ident<const BASE_ADDR: usize> {
+                _inner: ()
+            }
+
+            impl<const BASE_ADDR: usize> #owned_ident<BASE_ADDR> {
+                /// Create a new object representing ownership of a peripheral at an
+                /// address.
+                ///
+                /// # Safety
+                ///
+                /// The `BASE_ADDR` given must be an address that has suitable
+                /// alignment, and must point to an object which matches the layout
+                /// given by the structure pointed to.
+                ///
+                /// If you create multiple instances of this handle at the same
+                /// time, you are responsible for ensuring that there are no
+                /// read-modify-write races on any of the registers.
+                ///
+                /// The [core::marker::Send] trait is implemented for the Owned
+                /// handle. However, there are cases where this implementation might
+                /// be incorrect, for example if an Owned handle was created for a
+                /// core-local private address.
+                ///
+                /// In that case, it it is recommended to [un-implement
+                /// Send](https://doc.rust-lang.org/nomicon/send-and-sync.html). on
+                /// the register block structure.
+                pub const unsafe fn new() -> Self {
+                    Self {
+                        _inner: ()
+                    }
+                }
+
+                /// Borrow the owned handle so it can be accessed
+                ///
+                /// This turns a zero-sized object with an address known at
+                /// compile-time into an object the size of a pointer, which has all
+                /// the read, write and modify access methods.
+                pub fn borrow_mut<'owner>(&'owner mut self) -> #wrapper_ident<'owner> {
+                    #wrapper_ident {
+                        ptr: BASE_ADDR as *mut _,
+                        phantom: core::marker::PhantomData,
+                    }
+                }
+            }
+        })
+    };
+
     let vis = input.vis;
 
     // combine the fragments into the desired output code
@@ -221,6 +281,7 @@ fn try_derive_mmio(input: DeriveInput) -> syn::Result<proc_macro2::TokenStream> 
             #constructors
         }
 
+        #owned_handles
     };
     Ok(tokens)
 }

--- a/macro/src/lib.rs
+++ b/macro/src/lib.rs
@@ -196,7 +196,7 @@ fn try_derive_mmio(input: DeriveInput) -> syn::Result<proc_macro2::TokenStream> 
                     }
                 }
 
-                /// Borrow the owned handle so it can be accessed
+                /// Mutably borrow the owned handle so it can be accessed
                 ///
                 /// This turns a zero-sized object with an address known at
                 /// compile-time into an object the size of a pointer, which has all
@@ -206,6 +206,20 @@ fn try_derive_mmio(input: DeriveInput) -> syn::Result<proc_macro2::TokenStream> 
                         ptr: BASE_ADDR as *mut _,
                         phantom: core::marker::PhantomData,
                     }
+                }
+
+                /// Immutably borrow the owned handle so it can be accessed
+                ///
+                /// This turns a zero-sized object with an address known at
+                /// compile-time into an object the size of a pointer, which has all
+                /// the read access methods.
+                pub fn borrow<'owner>(&'owner self) -> derive_mmio::SharedInner<#wrapper_ident<'owner>> {
+                    derive_mmio::SharedInner::__new_internal(
+                        #wrapper_ident {
+                            ptr: BASE_ADDR as *mut _,
+                            phantom: core::marker::PhantomData,
+                        }
+                    )
                 }
             }
         })

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -327,6 +327,41 @@ impl MmioUart {
 }
 ```
 
+## Owned Handles
+
+As well as `Mmio${StructName}`, you also get a type called `Owned${StructName}<const BASE_ADDR: usize>`.
+This allows you to represent ownership of a peripheral, but it takes up zero-bytes and so is cheaper
+to hold than an `Mmio${StructName}` (which is the size of a pointer). The trade-off is that you must
+call its `borrow_mut` method to actually get an `Mmio${StructName}` in order to actually access the
+peripheral, and that the base address of the peripheral must be known at compile-time.
+
+```rust,ignore
+#[derive(derive_mmio::Mmio)]
+#[repr(C)]
+struct Regs {
+    data: u32,
+    control: u32,
+    status: u32
+}
+
+pub struct UartDriver {
+    uart: OwnedRegs<0xE000_C100>
+}
+
+impl UartDriver {
+    fn read_data(&mut self) -> u32 {
+        let mut mmio_handle = self.uart.borrow_mut();
+        mmio_handle.read_data();
+    }
+}
+```
+
+If we had built `UartDriver` with an `MmioUart` inside, it would have taken up four bytes of RAM.
+By using an `OwnedUart` it takes up zero bytes.
+
+You can disable the generation of the Owned handle by adding a `#[mmio(no_owned)]` attribute
+annotation to your peripheral block structure.
+
 ## Supported attributes
 
 The following attributes are supported for fields with a struct which is wrapped

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,8 @@ In Rust, we have some issues:
 3. Accessing a field of a struct without constructing a pointer to it used
    to be quite tricky, although as of Rust 1.51 we have
    [`core::ptr::addr_of_mut`] and as of Rust 1.84 we have `&raw mut`.
+4. You cannot call a method using a pointer (i.e. there is no `(*mut self)`
+   method receiver`).
 
 The usual solution to these problems is to auto-generate code based on some
 machine-readable (but non-Rust) description of the MMIO peripheral. This

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -349,9 +349,17 @@ pub struct UartDriver {
 }
 
 impl UartDriver {
-    fn read_data(&mut self) -> u32 {
-        let mut mmio_handle = self.uart.borrow_mut();
-        mmio_handle.read_data();
+    pub fn write_data(&mut self, data: u32) {
+        let mut mmio_uart = self.uart.borrow_mut();
+        mmio_uart.write_data(data);
+    }
+
+    pub fn read_data(&self) -> u32 {
+        let mmio_uart = self.uart.borrow();
+        // This won't work - only have shared access:
+        // mmio_uart.write_data(0);
+        // This does work:
+        mmio_uart.read_data()
     }
 }
 ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,7 @@ In Rust, we have some issues:
    to be quite tricky, although as of Rust 1.51 we have
    [`core::ptr::addr_of_mut`] and as of Rust 1.84 we have `&raw mut`.
 4. You cannot call a method using a pointer (i.e. there is no `(*mut self)`
-   method receiver`).
+   method receiver).
 
 The usual solution to these problems is to auto-generate code based on some
 machine-readable (but non-Rust) description of the MMIO peripheral. This

--- a/tests/derives_debug.rs
+++ b/tests/derives_debug.rs
@@ -16,12 +16,6 @@ pub fn main() {
 
     // Verify that the debug implementation simply shows the base address const generic.
     let owned_uart: OwnedUart<256> = unsafe { OwnedUart::new() };
-    assert_eq!(
-        format!("{:?}", owned_uart),
-        format!("OwnedUart(256)")
-    );
-    assert_eq!(
-        format!("{:04x?}", owned_uart),
-        format!("OwnedUart(0100)")
-    );
+    assert_eq!(format!("{:?}", owned_uart), format!("OwnedUart(256)"));
+    assert_eq!(format!("{:04x?}", owned_uart), format!("OwnedUart(0100)"));
 }

--- a/tests/derives_debug.rs
+++ b/tests/derives_debug.rs
@@ -13,4 +13,15 @@ pub fn main() {
     let addr = core::ptr::addr_of!(uart);
     // Verify that the debug implementation simply shows the base address.
     assert_eq!(format!("{:?}", mmio_uart), format!("MmioUart({:?})", addr));
+
+    // Verify that the debug implementation simply shows the base address const generic.
+    let owned_uart: OwnedUart<256> = unsafe { OwnedUart::new() };
+    assert_eq!(
+        format!("{:?}", owned_uart),
+        format!("OwnedUart(256)")
+    );
+    assert_eq!(
+        format!("{:04x?}", owned_uart),
+        format!("OwnedUart(0100)")
+    );
 }

--- a/tests/no_compile/bad_outer_attr.stderr
+++ b/tests/no_compile/bad_outer_attr.stderr
@@ -1,4 +1,4 @@
-error: invalid content of mmio attribute, allowed values: `no_ctors`, `const_ptr`, `const_inner`
+error: invalid content of mmio attribute, allowed values: `no_ctors`, `no_owned`, `const_ptr`, `const_inner`
  --> tests/no_compile/bad_outer_attr.rs:2:1
   |
 2 | #[mmio(no_ctors_x)]

--- a/tests/no_compile/no_owned.rs
+++ b/tests/no_compile/no_owned.rs
@@ -1,0 +1,22 @@
+#[derive(derive_mmio::Mmio)]
+#[mmio(no_owned)]
+#[repr(C)]
+struct Uart {
+    data: u32,
+}
+
+struct Driver {
+    uart: OwnedUart<0x1234_5678>,
+}
+
+impl Driver {
+    #[allow(dead_code)]
+    pub fn read_data(&mut self) -> u32 {
+        let mmio_uart = self.uart.borrow_mut();
+        mmio_uart.read_data()
+    }
+}
+
+fn main() {
+    // Can not really test this on a host environment. Simply verify that it fails to build.
+}

--- a/tests/no_compile/no_owned.stderr
+++ b/tests/no_compile/no_owned.stderr
@@ -1,0 +1,5 @@
+error[E0412]: cannot find type `OwnedUart` in this scope
+ --> tests/no_compile/no_owned.rs:9:11
+  |
+9 |     uart: OwnedUart<0x1234_5678>,
+  |           ^^^^^^^^^ not found in this scope

--- a/tests/no_compile/owned_borrow.rs
+++ b/tests/no_compile/owned_borrow.rs
@@ -1,0 +1,22 @@
+#[derive(derive_mmio::Mmio)]
+#[repr(C)]
+struct Uart {
+    data: u32,
+}
+
+struct Driver {
+    uart: OwnedUart<0x1234_5678>,
+}
+
+impl Driver {
+    #[allow(dead_code)]
+    pub fn write_data(&mut self, data: u32) {
+        let mmio_uart = self.uart.borrow();
+        // we did the wrong kind of borrow
+        mmio_uart.write_data(data);
+    }
+}
+
+fn main() {
+    // Can not really test this on a host environment. Simply verify that it fails to build.
+}

--- a/tests/no_compile/owned_borrow.stderr
+++ b/tests/no_compile/owned_borrow.stderr
@@ -1,0 +1,7 @@
+error[E0596]: cannot borrow data in dereference of `SharedInner<MmioUart<'_>>` as mutable
+  --> tests/no_compile/owned_borrow.rs:16:9
+   |
+16 |         mmio_uart.write_data(data);
+   |         ^^^^^^^^^ cannot borrow as mutable
+   |
+   = help: trait `DerefMut` is required to modify through a dereference, but it is not implemented for `SharedInner<MmioUart<'_>>`

--- a/tests/owned_handle.rs
+++ b/tests/owned_handle.rs
@@ -1,0 +1,22 @@
+#[derive(derive_mmio::Mmio)]
+#[mmio(no_ctors)]
+#[repr(C)]
+struct Uart {
+    data: u32,
+}
+
+struct Driver {
+    uart: OwnedUart<0x1234_5678>,
+}
+
+impl Driver {
+    #[allow(dead_code)]
+    pub fn read_data(&mut self) -> u32 {
+        let mmio_uart = self.uart.borrow_mut();
+        mmio_uart.read_data()
+    }
+}
+
+fn main() {
+    // Can not really test this on a host environment. Simply verify that it builds.
+}

--- a/tests/owned_handle.rs
+++ b/tests/owned_handle.rs
@@ -11,8 +11,14 @@ struct Driver {
 
 impl Driver {
     #[allow(dead_code)]
-    pub fn read_data(&mut self) -> u32 {
-        let mmio_uart = self.uart.borrow_mut();
+    pub fn write_data(&mut self, data: u32) {
+        let mut mmio_uart = self.uart.borrow_mut();
+        mmio_uart.write_data(data);
+    }
+
+    #[allow(dead_code)]
+    pub fn read_data(&self) -> u32 {
+        let mmio_uart = self.uart.borrow();
         mmio_uart.read_data()
     }
 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -10,6 +10,7 @@ fn all_tests() {
     t.pass("tests/inner_mmio_array.rs");
     t.pass("tests/no_ctors.rs");
     t.pass("tests/derives_debug.rs");
+    t.pass("tests/owned_handle.rs");
 
     // tests that pass but need an specific rustc version
 
@@ -33,6 +34,7 @@ fn all_tests() {
     t.compile_fail("tests/no_compile/modify_without_read.rs");
     t.compile_fail("tests/no_compile/modify_without_write.rs");
     t.compile_fail("tests/no_compile/no_modify.rs");
+    t.compile_fail("tests/no_compile/no_owned.rs");
     t.compile_fail("tests/no_compile/padding_forbidden.rs");
     t.compile_fail("tests/no_compile/read_only.rs");
     t.compile_fail("tests/no_compile/repr_c_mandatory.rs");

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -35,6 +35,7 @@ fn all_tests() {
     t.compile_fail("tests/no_compile/modify_without_write.rs");
     t.compile_fail("tests/no_compile/no_modify.rs");
     t.compile_fail("tests/no_compile/no_owned.rs");
+    t.compile_fail("tests/no_compile/owned_borrow.rs");
     t.compile_fail("tests/no_compile/padding_forbidden.rs");
     t.compile_fail("tests/no_compile/read_only.rs");
     t.compile_fail("tests/no_compile/repr_c_mandatory.rs");


### PR DESCRIPTION
An owned handle is a zero-sized type that represents a peripheral whose base address is known at compile time. It can be converted into an Mmio handle at run-time using the `borrow_mut` method.

This means driver in a HAL, say a UART driver, doesn't need to hold onto a four-byte MmioRegs object all the time. It can hold a zero-sized OwnedRegs object, and conjure up an MmioRegs object on demand. If you have a lot of drivers, this space saving can be useful.

The trade-off is that the base address does need to be known at compile time, but it usually is because it's fixed by the SoC.