### PR TITLE
Bump to checkout@v7

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
       matrix: ${{ fromJSON(needs.setup.outputs.matrix) }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Install rust
         run: |
           rustup install ${{ matrix.rust }}
@@ -45,7 +45,7 @@ jobs:
           - thumbv7em-none-eabihf
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Install rust
         run: |
           rustup install ${{ matrix.rust }}
@@ -63,7 +63,7 @@ jobs:
       matrix: ${{ fromJSON(needs.setup.outputs.matrix) }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Install rust
         run: |
           rustup install ${{ matrix.rust }}
@@ -85,7 +85,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Install rust
         run: |
           rustup install 1.85
@@ -100,7 +100,7 @@ jobs:
       matrix: ${{ fromJSON(needs.setup.outputs.matrix) }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Install rust
         run: |
           rustup install ${{ matrix.rust }}
@@ -114,7 +114,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Install rust
         run: |
           rustup install stable
@@ -135,7 +135,7 @@ jobs:
       matrix: ${{ fromJSON(needs.setup.outputs.matrix) }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Install rust
         run: |
           rustup install ${{ matrix.rust }}


### PR DESCRIPTION
https://github.com/actions/checkout reports it has:

> Safer fork pull request handling: checkout now refuses to check out
> fork pull request code by default when the workflow is triggered by
> pull_request_target or workflow_run.