### PR TITLE
Bump to version 0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v0.7.0] - 2026-06-29
+
 ### Added
 
 - API for getting the length of an array of registers (`len_XXX`)
@@ -93,7 +95,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - First release
 - Provides `read_xxx`, `write_xxx` and `modify_xxx` methods
 
-[Unreleased]: https://github.com/knurling-rs/derive-mmio/compare/derive-mmio-v0.6.0...HEAD
+[Unreleased]: https://github.com/knurling-rs/derive-mmio/compare/derive-mmio-v0.7.0...HEAD
+[v0.7.0]: https://github.com/knurling-rs/derive-mmio/compare/derive-mmio-v0.6.1...derive-mmio-v0.7.0
+[v0.6.1]: https://github.com/knurling-rs/derive-mmio/compare/derive-mmio-v0.6.0...derive-mmio-v0.6.1
 [v0.6.0]: https://github.com/knurling-rs/derive-mmio/compare/derive-mmio-v0.5.0...derive-mmio-v0.6.0
 [v0.5.0]: https://github.com/knurling-rs/derive-mmio/compare/derive-mmio-v0.4.0...derive-mmio-v0.5.0
 [v0.4.0]: https://github.com/knurling-rs/derive-mmio/compare/derive-mmio-v0.3.0...derive-mmio-v0.4.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,10 +9,10 @@ name = "derive-mmio"
 readme = "README.md"
 repository = "https://github.com/knurling-rs/derive-mmio"
 rust-version = "1.85"
-version = "0.6.1"
+version = "0.7.0"
 
 [dependencies]
-derive-mmio-macro = { version = "=0.6.1", path = "./macro" }
+derive-mmio-macro = { version = "=0.7.0", path = "./macro" }
 defmt = { version = "1", optional = true }
 rustversion = "1"
 

--- a/macro/Cargo.toml
+++ b/macro/Cargo.toml
@@ -8,7 +8,7 @@ name = "derive-mmio-macro"
 readme = "../README.md"
 repository = "https://github.com/knurling-rs/derive-mmio"
 rust-version = "1.70"
-version = "0.6.1"
+version = "0.7.0"
 
 [lib]
 proc-macro = true


### PR DESCRIPTION
Let's do a v0.7.0 release:

### Added

- API for getting the length of an array of registers (`len_XXX`)

### Changed

- Swapped from `proc-macro-error2` to `syn::Error`
- Renamed the API for getting the length of an inner block of registers (from `XXX_array_len` to `len_XXX`)
- The generated wrapper struct now `#[repr(transparent)]`.
- Bumped MSRV to 1.85
