### PR TITLE
Bump to v0.6.2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - id: set-matrix
         run: |
-          echo 'rust_versions={"rust": ["stable", "1.70"]}' >> "$GITHUB_OUTPUT"
+          echo 'rust_versions={"rust": ["stable", "1.85"]}' >> "$GITHUB_OUTPUT"
 
   # Build the library
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
       matrix: ${{ fromJSON(needs.setup.outputs.matrix) }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Install rust
         run: |
           rustup install ${{ matrix.rust }}
@@ -45,7 +45,7 @@ jobs:
           - thumbv7em-none-eabihf
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Install rust
         run: |
           rustup install ${{ matrix.rust }}
@@ -63,7 +63,7 @@ jobs:
       matrix: ${{ fromJSON(needs.setup.outputs.matrix) }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Install rust
         run: |
           rustup install ${{ matrix.rust }}
@@ -85,9 +85,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
-      - run: cargo test
+        uses: actions/checkout@v7
+      - name: Install rust
+        run: |
+          rustup install 1.85
+          rustup default 1.85
+      - run: cargo test --all-targets
 
   # Build the docs for the library
   docs:
@@ -97,7 +100,7 @@ jobs:
       matrix: ${{ fromJSON(needs.setup.outputs.matrix) }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Install rust
         run: |
           rustup install ${{ matrix.rust }}
@@ -111,7 +114,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Install rust
         run: |
           rustup install stable
@@ -132,7 +135,7 @@ jobs:
       matrix: ${{ fromJSON(needs.setup.outputs.matrix) }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Install rust
         run: |
           rustup install ${{ matrix.rust }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
       matrix: ${{ fromJSON(needs.setup.outputs.matrix) }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Install rust
         run: |
           rustup install ${{ matrix.rust }}
@@ -45,7 +45,7 @@ jobs:
           - thumbv7em-none-eabihf
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Install rust
         run: |
           rustup install ${{ matrix.rust }}
@@ -63,7 +63,7 @@ jobs:
       matrix: ${{ fromJSON(needs.setup.outputs.matrix) }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Install rust
         run: |
           rustup install ${{ matrix.rust }}
@@ -85,7 +85,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - run: cargo test
 
@@ -97,7 +97,7 @@ jobs:
       matrix: ${{ fromJSON(needs.setup.outputs.matrix) }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Install rust
         run: |
           rustup install ${{ matrix.rust }}
@@ -111,7 +111,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Install rust
         run: |
           rustup install stable
@@ -132,7 +132,7 @@ jobs:
       matrix: ${{ fromJSON(needs.setup.outputs.matrix) }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Install rust
         run: |
           rustup install ${{ matrix.rust }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## v0.6.next [Unreleased]
+## [Unreleased]
+
+## [v0.6.2] = 2026-06-29
 
 ### Added
 
@@ -88,7 +90,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - First release
 - Provides `read_xxx`, `write_xxx` and `modify_xxx` methods
 
-[Unreleased]: https://github.com/knurling-rs/derive-mmio/compare/derive-mmio-v0.6.0...version-0.6.x
+[Unreleased]: https://github.com/knurling-rs/derive-mmio/compare/derive-mmio-v0.6.2...version-0.6.x
+[v0.6.2]: https://github.com/knurling-rs/derive-mmio/compare/derive-mmio-v0.6.1...derive-mmio-v0.6.2
+[v0.6.1]: https://github.com/knurling-rs/derive-mmio/compare/derive-mmio-v0.6.0...derive-mmio-v0.6.1
 [v0.6.0]: https://github.com/knurling-rs/derive-mmio/compare/derive-mmio-v0.5.0...derive-mmio-v0.6.0
 [v0.5.0]: https://github.com/knurling-rs/derive-mmio/compare/derive-mmio-v0.4.0...derive-mmio-v0.5.0
 [v0.4.0]: https://github.com/knurling-rs/derive-mmio/compare/derive-mmio-v0.3.0...derive-mmio-v0.4.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## v0.6.next [Unreleased]
+
+### Added
+
+### Changed
+
+- The generated wrapper struct now `#[repr(transparent)]`.
 
 ## [v0.6.1] - 2025-09-03
 
@@ -81,7 +87,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - First release
 - Provides `read_xxx`, `write_xxx` and `modify_xxx` methods
 
-[Unreleased]: https://github.com/knurling-rs/derive-mmio/compare/derive-mmio-v0.6.0...HEAD
+[Unreleased]: https://github.com/knurling-rs/derive-mmio/compare/derive-mmio-v0.6.0...version-0.6.x
 [v0.6.0]: https://github.com/knurling-rs/derive-mmio/compare/derive-mmio-v0.5.0...derive-mmio-v0.6.0
 [v0.5.0]: https://github.com/knurling-rs/derive-mmio/compare/derive-mmio-v0.4.0...derive-mmio-v0.5.0
 [v0.4.0]: https://github.com/knurling-rs/derive-mmio/compare/derive-mmio-v0.3.0...derive-mmio-v0.4.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Swapped from `proc-macro-error2` to `syn::Error`
 - The generated wrapper struct now `#[repr(transparent)]`.
 
 ## [v0.6.1] - 2025-09-03

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,10 +9,10 @@ name = "derive-mmio"
 readme = "README.md"
 repository = "https://github.com/knurling-rs/derive-mmio"
 rust-version = "1.70"
-version = "0.6.1"
+version = "0.6.2"
 
 [dependencies]
-derive-mmio-macro = { version = "=0.6.1", path = "./macro" }
+derive-mmio-macro = { version = "=0.6.2", path = "./macro" }
 defmt = { version = "1", optional = true }
 rustversion = "1"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 name = "derive-mmio"
 readme = "README.md"
 repository = "https://github.com/knurling-rs/derive-mmio"
-rust-version = "1.70"
+rust-version = "1.85"
 version = "0.6.2"
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ For more details about the framework check the documentation at
 
 ## MSRV
 
-The minimum supported Rust version is 1.76 (or Ferrocene 24.05). `derive-mmio`
+The minimum supported Rust version is 1.85 (or Ferrocene 25.05). `derive-mmio`
 is tested against the latest stable Rust version and the MSRV.
 
 ## Support

--- a/macro/Cargo.toml
+++ b/macro/Cargo.toml
@@ -14,7 +14,6 @@ version = "0.6.1"
 proc-macro = true
 
 [dependencies]
-proc-macro-error2 = "2.0.1"
 proc-macro2 = "1.0.93"
 quote = "1.0.38"
 syn = "2.0.98"

--- a/macro/Cargo.toml
+++ b/macro/Cargo.toml
@@ -8,7 +8,7 @@ name = "derive-mmio-macro"
 readme = "../README.md"
 repository = "https://github.com/knurling-rs/derive-mmio"
 rust-version = "1.70"
-version = "0.6.1"
+version = "0.6.2"
 
 [lib]
 proc-macro = true

--- a/macro/Cargo.toml
+++ b/macro/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT OR Apache-2.0"
 name = "derive-mmio-macro"
 readme = "../README.md"
 repository = "https://github.com/knurling-rs/derive-mmio"
-rust-version = "1.70"
+rust-version = "1.85"
 version = "0.6.2"
 
 [lib]

--- a/macro/src/lib.rs
+++ b/macro/src/lib.rs
@@ -144,6 +144,7 @@ pub fn derive_mmio(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
         #[doc = "An MMIO wrapper for ["]
         #[doc = stringify!(#ident)]
         #[doc = "]"]
+        #[repr(transparent)]
         pub struct #wrapper_ident<'a> {
             ptr: *mut #ident,
             phantom: core::marker::PhantomData<&'a ()>,

--- a/macro/src/lib.rs
+++ b/macro/src/lib.rs
@@ -1,18 +1,22 @@
 //! The derive macro for the Mmio crate.
 
 use proc_macro2::TokenStream;
-use proc_macro_error2::{abort, abort_call_site, proc_macro_error};
 use quote::{format_ident, quote, ToTokens, TokenStreamExt};
 use syn::{
     parse_macro_input, punctuated::Punctuated, spanned::Spanned, Data, DeriveInput, Field, Fields,
     Ident, Meta, Path, Token, TypeArray, TypePath,
 };
 
-#[proc_macro_error]
 #[proc_macro_derive(Mmio, attributes(mmio))]
 pub fn derive_mmio(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     // validate our input
     let input = parse_macro_input!(input as DeriveInput);
+    try_derive_mmio(input)
+        .unwrap_or_else(syn::Error::into_compile_error)
+        .into()
+}
+
+fn try_derive_mmio(input: DeriveInput) -> syn::Result<proc_macro2::TokenStream> {
     let mut is_repr_c = false;
     let mut omit_ctor = false;
     let mut const_ptr = false;
@@ -37,7 +41,7 @@ pub fn derive_mmio(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
                         "invalid content of mmio attribute, allowed values: `no_ctors`, `const_ptr`, `const_inner`"
                     ))
                 }) {
-                    abort!(e);
+                    return Err(syn::Error::new(input.span(), e));
                 };
             }
         }
@@ -56,15 +60,24 @@ pub fn derive_mmio(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
         }
     }
     if !is_repr_c {
-        abort_call_site!("`#[derive(Mmio)]` only works on repr(C) types");
+        return Err(syn::Error::new(
+            input.ident.span(),
+            "`#[derive(Mmio)]` only works on repr(C) types",
+        ));
     }
-    let ident = input.ident;
+    let ident = &input.ident;
     let wrapper_ident = format_ident!("Mmio{}", ident);
     let Data::Struct(ref s) = input.data else {
-        abort_call_site!("`#[derive(Mmio)]` only supports struct");
+        return Err(syn::Error::new(
+            input.span(),
+            "`#[derive(Mmio)]` only supports struct",
+        ));
     };
     let Fields::Named(ref fields) = &s.fields else {
-        abort_call_site!("`#[derive(Mmio)]` only supports structs with named fields");
+        return Err(syn::Error::new(
+            input.span(),
+            "`#[derive(Mmio)]` only supports structs with named fields",
+        ));
     };
 
     let config = FieldConfig {
@@ -80,7 +93,8 @@ pub fn derive_mmio(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
         .filter(|(_field, field_ident)| !field_ident.to_string().starts_with("_"))
         .map(|(field, field_ident)| {
             field_parser.generate_access_methods(&ident, field, field_ident)
-        });
+        })
+        .collect::<syn::Result<Vec<_>>>()?;
 
     let access_methods_quoted = quote! {
         #(#access_methods)*
@@ -140,7 +154,7 @@ pub fn derive_mmio(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let vis = input.vis;
 
     // combine the fragments into the desired output code
-    proc_macro::TokenStream::from(quote! {
+    let tokens = quote! {
         #[doc = "An MMIO wrapper for ["]
         #[doc = stringify!(#ident)]
         #[doc = "]"]
@@ -199,7 +213,8 @@ pub fn derive_mmio(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
             #constructors
         }
 
-    })
+    };
+    Ok(tokens)
 }
 
 /// Convert a field into code that returns the field size
@@ -261,14 +276,17 @@ impl FieldParser {
         ident: &Ident,
         field: &Field,
         field_ident: &Ident,
-    ) -> TokenStream {
+    ) -> syn::Result<TokenStream> {
         let mut access = AccessModifiers::default();
         for attr in field.attrs.iter() {
             if attr.path().is_ident("mmio") {
                 let Ok(nested) =
                     attr.parse_args_with(Punctuated::<Meta, Token![,]>::parse_terminated)
                 else {
-                    abort!(attr.span(), "`Failed to parse #[mmio(...)]`");
+                    return Err(syn::Error::new(
+                        attr.span(),
+                        "`Failed to parse #[mmio(...)]`",
+                    ));
                 };
                 let unexpected_meta_printout =
                     "`#[mmio(...)]` only supports 'Inner', 'Read', 'PureRead', 'Write', and 'Modify' options";
@@ -282,39 +300,51 @@ impl FieldParser {
                             );
                         } else if path.is_ident("Read") {
                             if access.read.is_some() {
-                                abort!(attr.span(), "`#[mmio(...)]` found second read argument");
+                                return Err(syn::Error::new(
+                                    attr.span(),
+                                    "`#[mmio(...)]` found second read argument",
+                                ));
                             }
                             access.read = Some(ReadAccess::Normal);
                         } else if path.is_ident("PureRead") {
                             if access.read.is_some() {
-                                abort!(attr.span(), "`#[mmio(...)]` found second read argument");
+                                return Err(syn::Error::new(
+                                    attr.span(),
+                                    "`#[mmio(...)]` found second read argument",
+                                ));
                             }
                             access.read = Some(ReadAccess::Pure);
                         } else if path.is_ident("Write") {
                             if access.write {
-                                abort!(attr.span(), "`#[mmio(...)]` found second write argument");
+                                return Err(syn::Error::new(
+                                    attr.span(),
+                                    "`#[mmio(...)]` found second write argument",
+                                ));
                             }
                             access.write = true;
                         } else if path.is_ident("Modify") {
                             if access.modify {
-                                abort!(attr.span(), "`#[mmio(...)]` found second write argument");
+                                return Err(syn::Error::new(
+                                    attr.span(),
+                                    "`#[mmio(...)]` found second write argument",
+                                ));
                             }
                             access.modify = true;
                         } else {
-                            abort!(attr.span(), unexpected_meta_printout);
+                            return Err(syn::Error::new(attr.span(), unexpected_meta_printout));
                         }
                     } else {
-                        abort!(attr.span(), unexpected_meta_printout);
+                        return Err(syn::Error::new(attr.span(), unexpected_meta_printout));
                     }
                 }
             }
         }
 
         if access.modify && (access.read.is_none() || !access.write) {
-            abort!(
+            return Err(syn::Error::new(
                 field.span(),
-                "Detected Modify field attribute without read and/or write access specifiers"
-            );
+                "Detected Modify field attribute without read and/or write access specifiers",
+            ));
         }
         access.convert_unmodified();
 
@@ -341,7 +371,7 @@ impl FieldParser {
             _ => (),
         }
 
-        output
+        Ok(output)
     }
 
     /// Generate access methods for fields that are MMIO blocks.
@@ -350,33 +380,39 @@ impl FieldParser {
         ident: &Ident,
         field: &Field,
         field_ident: &Ident,
-    ) -> TokenStream {
+    ) -> syn::Result<TokenStream> {
         match &field.ty {
-            syn::Type::Path(type_path) => {
-                self.generate_access_method_for_single_inner_mmio(ident, field_ident, type_path)
-            }
+            syn::Type::Path(type_path) => Ok(self.generate_access_method_for_single_inner_mmio(
+                ident,
+                field_ident,
+                type_path,
+            )),
             syn::Type::Array(array_type) => {
                 if let syn::Type::Path(element_type) = array_type.elem.as_ref() {
-                    self.generate_access_method_for_inner_mmio_array(
+                    Ok(self.generate_access_method_for_inner_mmio_array(
                         ident,
                         field_ident,
                         array_type,
                         element_type,
-                    )
+                    ))
                 } else {
-                    abort!(
+                    return Err(syn::Error::new(
                         array_type.span(),
-                        "inner field array {} does not have a valid array type",
-                        field.to_token_stream()
-                    );
+                        format!(
+                            "inner field array {} does not have a valid array type",
+                            field.to_token_stream()
+                        ),
+                    ));
                 }
             }
             _ => {
-                abort!(
+                return Err(syn::Error::new(
                     field.span(),
-                    "inner field {} does not have a valid path",
-                    field.to_token_stream()
-                );
+                    format!(
+                        "inner field {} does not have a valid path",
+                        field.to_token_stream()
+                    ),
+                ));
             }
         }
     }

--- a/tests/no_compile/bad_outer_attr.stderr
+++ b/tests/no_compile/bad_outer_attr.stderr
@@ -1,5 +1,5 @@
 error: invalid content of mmio attribute, allowed values: `no_ctors`, `const_ptr`, `const_inner`
- --> tests/no_compile/bad_outer_attr.rs:2:8
+ --> tests/no_compile/bad_outer_attr.rs:2:1
   |
 2 | #[mmio(no_ctors_x)]
-  |        ^^^^^^^^^^
+  | ^

--- a/tests/no_compile/read_only.stderr
+++ b/tests/no_compile/read_only.stderr
@@ -9,6 +9,5 @@ error[E0599]: no method named `write_status` found for struct `MmioUart` in the 
    |
 help: there is a method `read_status` with a similar name
    |
-16 -     mmio_uart.write_status();
-16 +     mmio_uart.read_status();
-   |
+16 |     mmio_uart.read_status();
+   |               ~~~~~~~~~~~

--- a/tests/no_compile/repr_c_mandatory.stderr
+++ b/tests/no_compile/repr_c_mandatory.stderr
@@ -1,7 +1,5 @@
 error: `#[derive(Mmio)]` only works on repr(C) types
- --> tests/no_compile/repr_c_mandatory.rs:1:10
+ --> tests/no_compile/repr_c_mandatory.rs:2:8
   |
-1 | #[derive(derive_mmio::Mmio)]
-  |          ^^^^^^^^^^^^^^^^^
-  |
-  = note: this error originates in the derive macro `derive_mmio::Mmio` (in Nightly builds, run with -Z macro-backtrace for more info)
+2 | struct Uart {
+  |        ^^^^


### PR DESCRIPTION
This branch is for continuing the v0.6.x release.

The v0.7.0 release is now out but it has a breaking change on it. This 0.6.x branch cherry-picks some important fixes (like dropping proc-macro-error2, and making handles repr(transparent)) so people can pick them up automatically without doing an update to 0.7.