### PR TITLE
Prepare 0.8.0 release.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v0.8.0] - 2026-07-21
+
 ### Added
 
 - MMIO wrapper structures now implement `core::fmt::Debug`. The implementation simply shows

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,7 +103,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - First release
 - Provides `read_xxx`, `write_xxx` and `modify_xxx` methods
 
-[Unreleased]: https://github.com/knurling-rs/derive-mmio/compare/derive-mmio-v0.7.0...HEAD
+[Unreleased]: https://github.com/knurling-rs/derive-mmio/compare/derive-mmio-v0.8.0...HEAD
+[v0.8.0]: https://github.com/knurling-rs/derive-mmio/compare/derive-mmio-v0.7.0...derive-mmio-v0.8.0
 [v0.7.0]: https://github.com/knurling-rs/derive-mmio/compare/derive-mmio-v0.6.1...derive-mmio-v0.7.0
 [v0.6.1]: https://github.com/knurling-rs/derive-mmio/compare/derive-mmio-v0.6.0...derive-mmio-v0.6.1
 [v0.6.0]: https://github.com/knurling-rs/derive-mmio/compare/derive-mmio-v0.5.0...derive-mmio-v0.6.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,10 +9,10 @@ name = "derive-mmio"
 readme = "README.md"
 repository = "https://github.com/knurling-rs/derive-mmio"
 rust-version = "1.85"
-version = "0.7.0"
+version = "0.8.0"
 
 [dependencies]
-derive-mmio-macro = { version = "=0.7.0", path = "./macro" }
+derive-mmio-macro = { version = "=0.8.0", path = "./macro" }
 defmt = { version = "1", optional = true }
 rustversion = "1"
 

--- a/macro/Cargo.toml
+++ b/macro/Cargo.toml
@@ -8,7 +8,7 @@ name = "derive-mmio-macro"
 readme = "../README.md"
 repository = "https://github.com/knurling-rs/derive-mmio"
 rust-version = "1.70"
-version = "0.7.0"
+version = "0.8.0"
 
 [lib]
 proc-macro = true


### PR DESCRIPTION
The new OwnedXXX type is a breaking change, so we get a major version bump.