### PR TITLE
Offset checker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added `offset_bytes` field attribute which allows verifying field offsets.
+
 ## [v0.8.0] - 2026-07-21
 
 ### Added

--- a/examples/array.rs
+++ b/examples/array.rs
@@ -4,8 +4,10 @@ pub struct Uart {
     // No access modifiers: PureRead / Write / Modify by default
     control: u32,
     array_0: [u32; 4],
+    // Offset check work for array fields as well.
+    #[mmio(offset_bytes(0x14))]
     array_1: [u32; 2],
-    #[mmio(PureRead)]
+    #[mmio(PureRead, offset_bytes(0x1C))]
     array_read_only: [u32; 4],
     // Write-only e.g. 1WC regs.
     #[mmio(Write)]

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -13,14 +13,15 @@
 pub struct Uart {
     // No access modifiers: PureRead / Write / Modify by default
     data: u32,
-    #[mmio(Read, Write, Modify)]
+    // We can also verify offsets of the register.
+    #[mmio(Read, Write, Modify, offset_bytes(0x4))]
     control: u32,
     // this field is read-only, with no side effects for a read. Generated reader function
     // does not mutably borrow the MMIO block.
     #[mmio(PureRead)]
     status: u32,
     // this field is read-only, but has side effects (e.g. read clears error bits)
-    #[mmio(Read)]
+    #[mmio(Read, offset_bytes(0xC))]
     errors: u32,
     // this is ignored
     _reserved: u32,

--- a/examples/inner_block.rs
+++ b/examples/inner_block.rs
@@ -30,10 +30,11 @@ pub struct Uart {
     control: u32,
     #[mmio(Inner)]
     bank_0: inner::UartBank,
-    #[mmio(Inner)]
+    // You can also do offset checks on inner blocks.
+    #[mmio(Inner, offset_bytes(0x0C))]
     bank_1: inner::UartBank,
     // Arrays also work.
-    #[mmio(Inner)]
+    #[mmio(Inner, offset_bytes(0x14))]
     array: [inner::UartBank; 2],
 }
 

--- a/macro/src/lib.rs
+++ b/macro/src/lib.rs
@@ -531,7 +531,7 @@ impl FieldParser {
     ) {
         let expected_offset = offset_to_check as usize;
         let span = field.span();
-        self.offset_checks.push(quote_spanned! { span =>
+        self.offset_checks.push(quote_spanned! { span=>
             const _: () = const {
                 assert!(
                     core::mem::offset_of!(#ident, #field_ident) == #expected_offset,

--- a/macro/src/lib.rs
+++ b/macro/src/lib.rs
@@ -1,10 +1,10 @@
 //! The derive macro for the Mmio crate.
 
 use proc_macro2::TokenStream;
-use quote::{format_ident, quote, ToTokens, TokenStreamExt};
+use quote::{format_ident, quote, quote_spanned, ToTokens, TokenStreamExt};
 use syn::{
-    parse_macro_input, punctuated::Punctuated, spanned::Spanned, Data, DeriveInput, Field, Fields,
-    Ident, Meta, Path, Token, TypeArray, TypePath,
+    parse_macro_input, punctuated::Punctuated, spanned::Spanned, Data, DeriveInput, Expr, Field,
+    Fields, Ident, Lit, Meta, Path, Token, TypeArray, TypePath,
 };
 
 #[proc_macro_derive(Mmio, attributes(mmio))]
@@ -97,9 +97,7 @@ fn try_derive_mmio(input: DeriveInput) -> syn::Result<proc_macro2::TokenStream> 
         .iter()
         .map(|field| (field, field.ident.as_ref().unwrap()))
         .filter(|(_field, field_ident)| !field_ident.to_string().starts_with("_"))
-        .map(|(field, field_ident)| {
-            field_parser.generate_access_methods(&ident, field, field_ident)
-        })
+        .map(|(field, field_ident)| field_parser.generate_field_methods(&ident, field, field_ident))
         .collect::<syn::Result<Vec<_>>>()?;
 
     let access_methods_quoted = quote! {
@@ -107,6 +105,7 @@ fn try_derive_mmio(input: DeriveInput) -> syn::Result<proc_macro2::TokenStream> 
     };
     let field_sizes = fields.named.iter().map(field_size);
     let bound_checks = &field_parser.bound_checks;
+    let offset_checks = &field_parser.offset_checks;
     let mut bound_check_func = TokenStream::new();
     if !bound_checks.is_empty() {
         bound_check_func.append_all(quote! {
@@ -255,12 +254,12 @@ fn try_derive_mmio(input: DeriveInput) -> syn::Result<proc_macro2::TokenStream> 
         }
 
         impl #wrapper_ident<'_> {
-            const _FIELD_SIZE: usize = {
+            const _REG_BLOCK_SIZE: usize = {
                 0 #( + #field_sizes )*
             };
 
             // Must match expected size
-            const _SIZE_CHECK: [(); #wrapper_ident::_FIELD_SIZE] = [(); core::mem::size_of::<#ident>()];
+            const _SIZE_CHECK: [(); #wrapper_ident::_REG_BLOCK_SIZE] = [(); core::mem::size_of::<#ident>()];
 
             /// Unsafely clone the MMIO handle.
             ///
@@ -286,6 +285,8 @@ fn try_derive_mmio(input: DeriveInput) -> syn::Result<proc_macro2::TokenStream> 
         }
 
         unsafe impl derive_mmio::_MmioMarker for #wrapper_ident<'_> {}
+
+        #(#offset_checks)*
 
         /// The [core::marker::Send] trait is unsafely implemented because sending a register block pointer to another
         /// thread should not be an issue for most use-cases.
@@ -316,6 +317,39 @@ fn field_size(field: &Field) -> TokenStream {
     }
 }
 
+fn parse_offset_literal(expr: Expr) -> syn::Result<u64> {
+    let Expr::Lit(expr_lit) = expr else {
+        return Err(syn::Error::new(
+            expr.span(),
+            "offset must be an integer literal",
+        ));
+    };
+    let Lit::Int(lit) = expr_lit.lit else {
+        return Err(syn::Error::new(
+            expr_lit.lit.span(),
+            "offset must be an integer literal",
+        ));
+    };
+
+    let mut s = lit.to_string();
+    let suffix = lit.suffix();
+    if !suffix.is_empty() {
+        s = s
+            .strip_suffix(suffix)
+            .expect("Failed to strip suffix from integer literal")
+            .to_string()
+    }
+    let s = s.replace('_', "");
+
+    let value = if let Some(hex) = s.strip_prefix("0x").or_else(|| s.strip_prefix("0X")) {
+        u64::from_str_radix(hex, 16)
+    } else {
+        s.parse::<u64>()
+    };
+
+    value.map_err(|_| syn::Error::new(lit.span(), "invalid integer for `offset`"))
+}
+
 #[derive(Debug, Default, PartialEq, Eq)]
 enum ReadAccess {
     // Pure reads, no side effects.
@@ -326,13 +360,14 @@ enum ReadAccess {
 }
 
 #[derive(Debug, Default)]
-struct AccessModifiers {
+struct FieldAttributes {
+    offset_to_check: Option<u64>,
     read: Option<ReadAccess>,
     write: bool,
     modify: bool,
 }
 
-impl AccessModifiers {
+impl FieldAttributes {
     pub fn convert_unmodified(&mut self) -> bool {
         if self.read.is_none() && !self.write && !self.modify {
             self.read = Some(ReadAccess::Pure);
@@ -351,6 +386,7 @@ struct FieldConfig {
 
 struct FieldParser {
     bound_checks: Vec<TokenStream>,
+    offset_checks: Vec<TokenStream>,
     config: FieldConfig,
 }
 
@@ -358,17 +394,23 @@ impl FieldParser {
     pub fn new(config: FieldConfig) -> Self {
         Self {
             bound_checks: Vec::new(),
+            offset_checks: Vec::new(),
             config,
         }
     }
     /// Convert a field into a set of methods that operate on that field
-    fn generate_access_methods(
+    ///
+    /// Also returns the size of the field, which can be larger than the register size for
+    /// inner MMIO blocks.
+    fn generate_field_methods(
         &mut self,
         ident: &Ident,
         field: &Field,
         field_ident: &Ident,
     ) -> syn::Result<TokenStream> {
-        let mut access = AccessModifiers::default();
+        let mut field_attrs = FieldAttributes::default();
+        let mut output = TokenStream::new();
+        let mut inner_mmio_detected = false;
         for attr in field.attrs.iter() {
             if attr.path().is_ident("mmio") {
                 let Ok(nested) =
@@ -384,45 +426,51 @@ impl FieldParser {
                 for meta in nested {
                     if let Meta::Path(path) = meta {
                         if path.is_ident("Inner") {
-                            return self.generate_access_method_for_inner_mmio_field(
+                            inner_mmio_detected = true;
+                            output.append_all(self.generate_access_method_for_inner_mmio_field(
                                 ident,
                                 field,
                                 field_ident,
-                            );
+                            ));
                         } else if path.is_ident("Read") {
-                            if access.read.is_some() {
+                            if field_attrs.read.is_some() {
                                 return Err(syn::Error::new(
                                     attr.span(),
                                     "`#[mmio(...)]` found second read argument",
                                 ));
                             }
-                            access.read = Some(ReadAccess::Normal);
+                            field_attrs.read = Some(ReadAccess::Normal);
                         } else if path.is_ident("PureRead") {
-                            if access.read.is_some() {
+                            if field_attrs.read.is_some() {
                                 return Err(syn::Error::new(
                                     attr.span(),
                                     "`#[mmio(...)]` found second read argument",
                                 ));
                             }
-                            access.read = Some(ReadAccess::Pure);
+                            field_attrs.read = Some(ReadAccess::Pure);
                         } else if path.is_ident("Write") {
-                            if access.write {
+                            if field_attrs.write {
                                 return Err(syn::Error::new(
                                     attr.span(),
                                     "`#[mmio(...)]` found second write argument",
                                 ));
                             }
-                            access.write = true;
+                            field_attrs.write = true;
                         } else if path.is_ident("Modify") {
-                            if access.modify {
+                            if field_attrs.modify {
                                 return Err(syn::Error::new(
                                     attr.span(),
                                     "`#[mmio(...)]` found second write argument",
                                 ));
                             }
-                            access.modify = true;
+                            field_attrs.modify = true;
                         } else {
                             return Err(syn::Error::new(attr.span(), unexpected_meta_printout));
+                        }
+                    } else if let Meta::List(list) = meta {
+                        if list.path.is_ident("offset_bytes") {
+                            field_attrs.offset_to_check =
+                                Some(parse_offset_literal(syn::parse2(list.tokens)?)? as u64);
                         }
                     } else {
                         return Err(syn::Error::new(attr.span(), unexpected_meta_printout));
@@ -431,20 +479,29 @@ impl FieldParser {
             }
         }
 
-        if access.modify && (access.read.is_none() || !access.write) {
+        if let Some(offset_to_check) = field_attrs.offset_to_check {
+            self.update_offset_checks(ident, field, field_ident, offset_to_check);
+        }
+
+        // Need an early return here. Otherwise, some invalid methods for inner MMIO blocks
+        // might be generated.
+        if inner_mmio_detected {
+            return Ok(output);
+        }
+
+        if field_attrs.modify && (field_attrs.read.is_none() || !field_attrs.write) {
             return Err(syn::Error::new(
                 field.span(),
                 "Detected Modify field attribute without read and/or write access specifiers",
             ));
         }
-        access.convert_unmodified();
+        field_attrs.convert_unmodified();
 
-        let mut output = TokenStream::new();
         match &field.ty {
             syn::Type::Array(type_array) => {
                 self.generate_array_access_methods(
                     ident,
-                    access,
+                    field_attrs,
                     field_ident,
                     type_array,
                     &mut output,
@@ -453,7 +510,7 @@ impl FieldParser {
             syn::Type::Path(type_path) => {
                 self.generate_field_access_methods(
                     ident,
-                    access,
+                    field_attrs,
                     field_ident,
                     type_path,
                     &mut output,
@@ -463,6 +520,29 @@ impl FieldParser {
         }
 
         Ok(output)
+    }
+
+    pub fn update_offset_checks(
+        &mut self,
+        ident: &Ident,
+        field: &Field,
+        field_ident: &Ident,
+        offset_to_check: u64,
+    ) {
+        let expected_offset = offset_to_check as usize;
+        let span = field.span();
+        self.offset_checks.push(quote_spanned! { span =>
+            const _: () = const {
+                assert!(
+                    core::mem::offset_of!(#ident, #field_ident) == #expected_offset,
+                    concat!(
+                        "Calculated offset for field `",
+                        stringify!(#field_ident),
+                        "` does not match given offset_bytes value"
+                    )
+                );
+            };
+        });
     }
 
     /// Generate access methods for fields that are MMIO blocks.
@@ -870,9 +950,9 @@ impl FieldParser {
     }
 
     fn generate_field_access_methods(
-        &self,
+        &mut self,
         ident: &Ident,
-        access: AccessModifiers,
+        field_attributes: FieldAttributes,
         field_ident: &Ident,
         type_path: &TypePath,
         access_methods: &mut TokenStream,
@@ -901,7 +981,7 @@ impl FieldParser {
                 unsafe { core::ptr::addr_of_mut!((*self.ptr).#field_ident) }
             }
         });
-        if let Some(read_access) = access.read {
+        if let Some(read_access) = field_attributes.read {
             let opt_mut = (read_access == ReadAccess::Normal).then_some(quote! { mut });
 
             access_methods.append_all(quote! {
@@ -917,7 +997,7 @@ impl FieldParser {
                 }
             });
         }
-        if access.write {
+        if field_attributes.write {
             access_methods.append_all(quote! {
                 #[doc = "Write the "]
                 #[doc = concat!("[", stringify!(#ident), "::", stringify!(#field_ident), "]")]
@@ -931,7 +1011,7 @@ impl FieldParser {
                 }
             });
         }
-        if access.modify {
+        if field_attributes.modify {
             access_methods.append_all(quote! {
             #[doc = "Read-Modify-Write the "]
             #[doc = concat!("[", stringify!(#ident), "::", stringify!(#field_ident), "]")]
@@ -949,7 +1029,7 @@ impl FieldParser {
     fn generate_array_access_methods(
         &self,
         ident: &Ident,
-        access: AccessModifiers,
+        access: FieldAttributes,
         field_ident: &Ident,
         type_array: &TypeArray,
         access_methods: &mut TokenStream,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -404,6 +404,9 @@ The access permission attributes work for array fields as well.
   `#[derive(Mmio)]`, which will be verified using trait bounds. The derive macro
   will generate getter functions to retrieve a handle for the inner block, with
   the lifetime of the inner handle tied to the outer handle.
+- `#[mmio(offset_bytes(0xAB))]` generates an offset check, which is useful to compare the offset
+   determined by the compiler against the field offset found in a datasheet. The offset needs to
+   be specified in bytes. This can be useful to protect against forgotten (padding) fields.
 
 If no permission access modifiers were specified, the library will default to
 `PureRead`, `Write`, `Modify` which is the default for most regular R/W

--- a/tests/array_fields.rs
+++ b/tests/array_fields.rs
@@ -6,6 +6,7 @@ struct Uart {
     control: u32,
     array_0: [u32; 4],
     other_field: u32,
+    #[mmio(offset_bytes(0x18))]
     array_1: [u32; 2],
     #[mmio(PureRead)]
     array_read_only: [u32; 4],

--- a/tests/inner_mmio.rs
+++ b/tests/inner_mmio.rs
@@ -13,7 +13,7 @@ struct Uart {
     control: u32,
     #[mmio(Inner)]
     bank_0: UartBank,
-    #[mmio(Inner)]
+    #[mmio(Inner, offset_bytes(0x0C))]
     bank_1: UartBank,
 }
 

--- a/tests/inner_mmio_array.rs
+++ b/tests/inner_mmio_array.rs
@@ -28,7 +28,8 @@ mod inner {
 #[repr(C)]
 pub struct Uart {
     control: u32,
-    #[mmio(Inner)]
+    // Offset checks work here as well.
+    #[mmio(Inner, offset_bytes(0x4))]
     banks: [inner::UartBank; 2],
 }
 

--- a/tests/no_compile/invalid_offset.rs
+++ b/tests/no_compile/invalid_offset.rs
@@ -1,0 +1,8 @@
+#[derive(derive_mmio::Mmio)]
+#[repr(C)]
+struct Uart {
+    #[mmio(offset_bytes(0x20))]
+    data: u32,
+}
+
+fn main() {}

--- a/tests/no_compile/invalid_offset.stderr
+++ b/tests/no_compile/invalid_offset.stderr
@@ -1,0 +1,13 @@
+error[E0080]: evaluation of `_::{constant#0}` failed
+ --> tests/no_compile/invalid_offset.rs:4:5
+  |
+4 |     #[mmio(offset_bytes(0x20))]
+  |     ^ the evaluated program panicked at 'Calculated offset for field `data` does not match given offset_bytes value', $DIR/tests/no_compile/invalid_offset.rs:4:5
+  |
+  = note: this error originates in the macro `$crate::panic::panic_2021` which comes from the expansion of the macro `assert` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+note: erroneous constant encountered
+ --> tests/no_compile/invalid_offset.rs:4:5
+  |
+4 |     #[mmio(offset_bytes(0x20))]
+  |     ^

--- a/tests/offset_syntax.rs
+++ b/tests/offset_syntax.rs
@@ -1,0 +1,11 @@
+#[derive(derive_mmio::Mmio)]
+#[repr(C)]
+struct Uart {
+    _reserved: [u32; 0x8],
+    #[mmio(offset_bytes(0x20))]
+    data: u32,
+    #[mmio(PureRead, offset_bytes(36))]
+    status: u32,
+}
+
+fn main() {}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -6,6 +6,7 @@ fn all_tests() {
 
     t.pass("tests/array_fields.rs");
     t.pass("tests/basic.rs");
+    t.pass("tests/offset_syntax.rs");
     t.pass("tests/inner_mmio.rs");
     t.pass("tests/inner_mmio_array.rs");
     t.pass("tests/no_ctors.rs");
@@ -30,6 +31,7 @@ fn all_tests() {
     t.compile_fail("tests/no_compile/inner_array_safe_unchecked.rs");
     t.compile_fail("tests/no_compile/inner_mmio_double_borrow.rs");
     t.compile_fail("tests/no_compile/inner_only_shared.rs");
+    t.compile_fail("tests/no_compile/invalid_offset.rs");
     t.compile_fail("tests/no_compile/modify_standalone.rs");
     t.compile_fail("tests/no_compile/modify_without_read.rs");
     t.compile_fail("tests/no_compile/modify_without_write.rs");


### PR DESCRIPTION
Fixes #63 .

I wish I could improve the compiler diagnostics / error output, but it is quite tricky because I could not find a way calculate/determine field offsets and sizes inside the macro code. I need to emit  the offsets as const variables and then have to work with those. I can not use `assert_eq!` because it is not allowed in const contexts.